### PR TITLE
Feature/teams page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ build:
 	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/creds-salt funcs/creds-salt/*.go;\
 	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/creds-provision funcs/creds-provision/*.go;\
 	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/team-create funcs/team-create/*.go;\
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/team-update funcs/team-update/*.go;\
 	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/teams-get funcs/teams-get/*.go;\
 	cd funcs;\
 	cd email-2fa && npm run zip && cd ../;\

--- a/serverless/funcs/guests-get/main.go
+++ b/serverless/funcs/guests-get/main.go
@@ -19,7 +19,7 @@ func GetGuestsHandler(ctx context.Context, event events.APIGatewayProxyRequest) 
 
 	parsed, err := data.ParseBodyData(event.Body)
 
-	team := parsed.Team
+	team := parsed.TeamId
 
 	if err != nil {
 		return msgs.SendServerError(err)

--- a/serverless/funcs/team-create/main.go
+++ b/serverless/funcs/team-create/main.go
@@ -36,7 +36,7 @@ func handleTeamCreation(teamName string) error {
 func NewTeamHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
 	parsed, err := data.ParseBodyData(event.Body)
 
-	team := parsed.Team
+	team := parsed.TeamId
 
 	if err != nil {
 		return msgs.SendServerError(err)

--- a/serverless/funcs/team-create/main.go
+++ b/serverless/funcs/team-create/main.go
@@ -36,7 +36,7 @@ func handleTeamCreation(teamName string) error {
 func NewTeamHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
 	parsed, err := data.ParseBodyData(event.Body)
 
-	team := parsed.TeamId
+	team := parsed.TeamName
 
 	if err != nil {
 		return msgs.SendServerError(err)
@@ -51,7 +51,20 @@ func NewTeamHandler(ctx context.Context, event events.APIGatewayProxyRequest) (m
 		return msgs.SendServerError(err)
 	}
 
-	return msgs.SendSuccessMessage()
+	// Return the full list of teams in the response.
+	teams, err := teams.RetrieveTeams()
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	body, err := msgs.MarshalBody(teams)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	return msgs.PrepareResponse(body)
 }
 
 func main() {

--- a/serverless/funcs/team-update/main.go
+++ b/serverless/funcs/team-update/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/IIP-Design/commons-gateway/utils/data/data"
+	"github.com/IIP-Design/commons-gateway/utils/data/teams"
+	"github.com/IIP-Design/commons-gateway/utils/logs"
+	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// TeamUpdateHandler handles the request to edit an existing team. It
+// ensures that the required data is present before continuing on to
+// update the team data.
+func TeamUpdateHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
+	parsed, err := data.ParseBodyData(event.Body)
+
+	active := parsed.Active
+	name := parsed.TeamName
+	team := parsed.TeamId
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	} else if team == "" {
+		logs.LogError(nil, "Team data not provided in request.")
+		return msgs.Response{StatusCode: 400}, errors.New("data missing from request")
+	}
+
+	exists, err := teams.CheckForExistingTeamById(team)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	} else if !exists {
+		return msgs.SendServerError(errors.New("no team with this id exists"))
+	}
+
+	if name != "" {
+		// If both active status and team name provided update full team info.
+		err = teams.UpdateTeam(team, name, active)
+	} else {
+		// If only status provided, update status.
+		err = teams.UpdateTeamStatus(team, active)
+	}
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	return msgs.SendSuccessMessage()
+}
+
+func main() {
+	lambda.Start(TeamUpdateHandler)
+}

--- a/serverless/funcs/team-update/main.go
+++ b/serverless/funcs/team-update/main.go
@@ -50,7 +50,20 @@ func TeamUpdateHandler(ctx context.Context, event events.APIGatewayProxyRequest)
 		return msgs.SendServerError(err)
 	}
 
-	return msgs.SendSuccessMessage()
+	// Return the full list of teams in the response.
+	teams, err := teams.RetrieveTeams()
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	body, err := msgs.MarshalBody(teams)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	return msgs.PrepareResponse(body)
 }
 
 func main() {

--- a/serverless/funcs/team-update/schema.json
+++ b/serverless/funcs/team-update/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "event.schema.json",
+  "title": "Event Body Format for Admin Create",
+  "description": "Data required to create a new admin user",
+  "type": "object",
+  "properties": {
+    "active": {
+      "type": "boolean"
+    },
+    "team": {
+      "type": "string",
+      "minLength": 1
+    },
+    "teamName": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": ["active", "team", "teamName"],
+  "additionalProperties": false
+}

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -153,6 +153,19 @@ functions:
     package:
       patterns:
         - './bin/team-create'
+  teamUpdate:
+    name: gateway-${opt:stage}-team-update
+    handler: bin/team-update
+    description: Edit the data for an exiting team.
+    runtime: go1.x
+    events:
+      - http:
+          path: /team/update
+          method: post
+          cors: ${file(./config/${param:deployment}.json):cors}
+    package:
+      patterns:
+        - './bin/team-update'
   teamsGet:
     name: gateway-${opt:stage}-teams-get
     handler: bin/teams-get

--- a/serverless/utils/data/data/parser.go
+++ b/serverless/utils/data/data/parser.go
@@ -12,6 +12,7 @@ import (
 // JSON object sent to the serverless functions by the API Gateway.
 type RequestBodyOptions struct {
 	Action  string `json:"action"`
+	Active  bool   `json:"active"`
 	Email   string `json:"email"`
 	Expires string `json:"expiration"`
 	Hash    string `json:"hash"`
@@ -24,7 +25,8 @@ type RequestBodyOptions struct {
 	Inviter   string `json:"inviter"`
 	NameFirst string `json:"givenName"`
 	NameLast  string `json:"familyName"`
-	Team      string `json:"team"`
+	TeamId    string `json:"team"`
+	TeamName  string `json:"teamName"`
 	Username  string `json:"username"`
 }
 
@@ -84,7 +86,7 @@ func ExtractUser(body string) (User, error) {
 	adminEmail := parsed.Email
 	firstName := parsed.NameFirst
 	lastName := parsed.NameLast
-	team := parsed.Team
+	team := parsed.TeamId
 
 	if err != nil {
 		return admin, err

--- a/serverless/utils/data/teams/teams.go
+++ b/serverless/utils/data/teams/teams.go
@@ -135,7 +135,7 @@ func RetrieveTeams() ([]map[string]any, error) {
 	pool := data.ConnectToDB()
 	defer pool.Close()
 
-	rows, err := pool.Query(`SELECT id, team_name, active FROM teams`)
+	rows, err := pool.Query(`SELECT id, team_name, active FROM teams ORDER BY team_name`)
 
 	if err != nil {
 		logs.LogError(err, "Get Teams Query Error")

--- a/web/src/components/TeamTable.tsx
+++ b/web/src/components/TeamTable.tsx
@@ -77,7 +77,12 @@ const TeamTable: FC = () => {
    */
   const handleStatusToggle = async ( status: boolean, id: string ) => {
     try {
-      await buildQuery( 'team/update', { active: status, team: id }, 'POST' );
+      const response = await buildQuery( 'team/update', { active: status, team: id }, 'POST' );
+      const { message } = await response.json();
+
+      if ( message ) {
+        showError( `Unable to complete your request. Reason: ${message}` );
+      }
     } catch ( err ) {
       console.log( err );
     }

--- a/web/src/components/TeamTable.tsx
+++ b/web/src/components/TeamTable.tsx
@@ -5,6 +5,7 @@ import ToggleSwitch from './ToggleSwitch/ToggleSwitch';
 import { buildQuery } from '../utils/api';
 import { selectSlice } from '../utils/arrays';
 import { renderCountWidget, setIntermediatePagination } from '../utils/pagination';
+import { showError } from '../utils/alert';
 
 import style from '../styles/table.module.scss';
 import btnStyle from '../styles/button.module.scss';
@@ -121,18 +122,26 @@ const TeamTable: FC = () => {
    */
   const saveTeam = async ( team: ITeam ) => {
     let newList;
+    let errMessage;
 
     // If the team is new, send a create request, otherwise send an update request.
     if ( team.id === 'temp' ) {
       const response = await buildQuery( 'team/create', { teamName: newName }, 'POST' );
-      const { data } = await response.json();
+      const { data, message } = await response.json();
 
       newList = data;
+      errMessage = message;
     } else {
       const response = await buildQuery( 'team/update', { active: team.active, team: team.id, teamName: newName }, 'POST' );
-      const { data } = await response.json();
+      const { data, message } = await response.json();
 
       newList = data;
+      errMessage = message;
+    }
+
+    if ( errMessage ) {
+      cancelEdit( team.id ); // Remove the placeholder if failed to add new item.
+      showError( `Unable to complete your request. Reason: ${errMessage}` );
     }
 
     // Update the team list with new data from the API.

--- a/web/src/components/TeamTable.tsx
+++ b/web/src/components/TeamTable.tsx
@@ -7,6 +7,7 @@ import { selectSlice } from '../utils/arrays';
 import { renderCountWidget, setIntermediatePagination } from '../utils/pagination';
 
 import style from '../styles/table.module.scss';
+import btnStyle from '../styles/button.module.scss';
 
 const TeamTable: FC = () => {
   // Set the high and low ends of the view toggle.
@@ -62,12 +63,25 @@ const TeamTable: FC = () => {
     setViewOffset( 0 );
   };
 
-  const handleStatusToggle = ( status: boolean, id: string ) => {
-    console.log( status, id );
+  const handleStatusToggle = async ( status: boolean, id: string ) => {
+    try {
+      const response = await buildQuery( 'team/update', { active: status, team: id }, 'POST' );
+      const { message } = await response.json();
+
+      console.log( message );
+    } catch ( err ) {
+      console.log( err );
+    }
   };
 
   return (
     <div className={ style.container }>
+      <button
+        className={ `${style['add-btn']} ${btnStyle.btn}` }
+        type="button"
+      >
+        + New Team
+      </button>
       <div>
         <div className={ style.controls }>
           <span>{ renderCountWidget( teamCount, viewCount, viewOffset ) }</span>

--- a/web/src/components/TeamTable.tsx
+++ b/web/src/components/TeamTable.tsx
@@ -14,12 +14,18 @@ const TeamTable: FC = () => {
   const LOW_VIEW = 30;
   const HIGH_VIEW = 90;
 
+  // State of the results pagination.
   const [viewCount, setViewCount] = useState( LOW_VIEW );
   const [viewOffset, setViewOffset] = useState( 0 );
+  // State of the full team list.
   const [teamList, setTeamList] = useState( selectSlice( [], viewCount, viewOffset ) );
-  const [teamCount, setTeamCount] = useState( teamList.length ); // eslint-disable-line no-unused-vars, @typescript-eslint/no-unused-vars
+  const [teamCount, setTeamCount] = useState( teamList.length );
+  // State used when add/editing a team.
+  const [editing, setEditing] = useState( '' );
+  const [newName, setNewName] = useState( '' );
 
   useEffect( () => {
+    // Retrieve the full list of teams from the API.
     const getTeams = async () => {
       const response = await buildQuery( 'teams', null, 'GET' );
       const { data } = await response.json();
@@ -63,15 +69,81 @@ const TeamTable: FC = () => {
     setViewOffset( 0 );
   };
 
+  /**
+   * Activate/deactivate a given team using the status toggle.
+   * @param status The active/inactive value the team should be set to.
+   * @param id The id of the team in question.
+   */
   const handleStatusToggle = async ( status: boolean, id: string ) => {
     try {
-      const response = await buildQuery( 'team/update', { active: status, team: id }, 'POST' );
-      const { message } = await response.json();
-
-      console.log( message );
+      await buildQuery( 'team/update', { active: status, team: id }, 'POST' );
     } catch ( err ) {
       console.log( err );
     }
+  };
+
+  /**
+   * Enable an input field to create a new team.
+   */
+  const addNewTeam = () => {
+    // Add a placeholder team with the id `temp`
+    teamList.unshift( { id: 'temp', active: true, name: '' } );
+    setEditing( 'temp' );
+  };
+
+  /**
+   * Enable an input field to alter an existing team name.
+   * @param id The id of the team to be altered.
+   * @param name The current name of the team.
+   */
+  const editTeam = ( id: string, name: string ) => {
+    setEditing( id );
+    setNewName( name );
+  };
+
+  /**
+   * Abort the editing/addition of a team.
+   * @param id The id of the team being altered.
+   */
+  const cancelEdit = ( id: string ) => {
+    setEditing( '' );
+    setNewName( '' );
+
+    // If canceling a team creation, remove the placeholder team.
+    if ( id === 'temp' ) {
+      teamList.shift();
+    }
+  };
+
+  /**
+   * Sends the user inputs on the team being created/updated to the API.
+   * @param team Information about the team to be created/edited.
+   */
+  const saveTeam = async ( team: ITeam ) => {
+    let newList;
+
+    // If the team is new, send a create request, otherwise send an update request.
+    if ( team.id === 'temp' ) {
+      const response = await buildQuery( 'team/create', { teamName: newName }, 'POST' );
+      const { data } = await response.json();
+
+      newList = data;
+    } else {
+      const response = await buildQuery( 'team/update', { active: team.active, team: team.id, teamName: newName }, 'POST' );
+      const { data } = await response.json();
+
+      newList = data;
+    }
+
+    // Update the team list with new data from the API.
+    if ( newList ) {
+      setTeamList( selectSlice( newList, viewCount, viewOffset ) );
+      setTeamCount( newList.length );
+    }
+
+    // Reset the state used when add/editing a team.
+    setEditing( '' );
+    setNewName( '' );
   };
 
   return (
@@ -79,6 +151,7 @@ const TeamTable: FC = () => {
       <button
         className={ `${style['add-btn']} ${btnStyle.btn}` }
         type="button"
+        onClick={ addNewTeam }
       >
         + New Team
       </button>
@@ -118,9 +191,26 @@ const TeamTable: FC = () => {
           <tbody>
             { teamList && ( teamList.map( team => (
               <tr key={ team.id }>
-                <td>{ team.name }</td>
                 <td>
-                  <ToggleSwitch active={ team.active } callback={ handleStatusToggle } id={ team.id } />
+                  { editing === team.id && (
+                    <input style={ { padding: '0.3rem 0.5rem' } } type="text" value={ newName } onChange={ e => setNewName( e.target.value ) } />
+                  ) }
+                  { editing !== team.id && (
+                    <button className={ style['pagination-btn'] } disabled={ editing !== '' } type="button" onClick={ () => editTeam( team.id, team.name ) }>
+                      { team.name }
+                    </button>
+                  ) }
+                </td>
+                <td>
+                  { editing === team.id && (
+                    <div>
+                      <button className={ btnStyle.btn } type="button" onClick={ () => saveTeam( team ) }>Save</button>
+                      <button className={ btnStyle['btn-light'] } style={ { marginLeft: '1rem' } } type="button" onClick={ () => cancelEdit( team.id ) }>Cancel</button>
+                    </div>
+                  ) }
+                  { editing !== team.id && (
+                    <ToggleSwitch active={ team.active } callback={ handleStatusToggle } id={ team.id } />
+                  ) }
                 </td>
               </tr>
             ) ) ) }

--- a/web/src/layouts/TableContainer.astro
+++ b/web/src/layouts/TableContainer.astro
@@ -7,7 +7,7 @@ const { btnHref, btnText, desc, narrow, title } = Astro.props;
 ---
 
 <PageContainer narrow={narrow} title={title}>
-  <AnchorButton class="add-btn" text={btnText} href={btnHref} />
+  {btnHref && <AnchorButton class="add-btn" text={btnText} href={btnHref} />}
   {desc && <p class="description">{desc}</p>}
   <div class="table">
     <slot />

--- a/web/src/pages/teams.astro
+++ b/web/src/pages/teams.astro
@@ -7,7 +7,7 @@ const title = 'Teams';
 ---
 
 <AdminPageLayout title={title}>
-  <TableContainer btnText="+ New Team" btnHref="newteam" narrow title={title}>
+  <TableContainer narrow title={title}>
     <TeamTable client:load />
   </TableContainer>
 </AdminPageLayout>

--- a/web/src/styles/button.module.scss
+++ b/web/src/styles/button.module.scss
@@ -1,10 +1,21 @@
-.btn,
-.btn:visited {
-  background-color: var(--blue);
-  color: #ffffff;
-  border: none;
+@mixin button-structure {
   border-radius: 5px;
   padding: 0.5rem 1rem;
+}
+
+.btn,
+.btn:visited {
+  @include button-structure;
+  border: none;
+  background-color: var(--blue);
+  color: #ffffff;
+}
+
+.btn-light {
+  @include button-structure;
+  border: 1px solid var(--blue);
+  background-color: #ffffff;
+  color: var(--blue);
 }
 
 .back-btn {

--- a/web/src/styles/table.module.scss
+++ b/web/src/styles/table.module.scss
@@ -1,3 +1,10 @@
+.add-btn {
+  position: absolute;
+  margin-right: 3rem;
+  right: 0;
+  transform: translateY(-6rem);
+}
+
 .container {
   min-height: 100%;
   display: flex;

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -10,6 +10,7 @@ interface IFetchBody {
   active?: boolean
   hash?: string
   team?: string
+  teamName?: string
   username?: string
   inviter?: string,
   invitee?: {

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -7,6 +7,7 @@ type TMethods = 'GET' | 'POST';
 /** The values that can be sent to the server. */
 interface IFetchBody {
   action?: TActions
+  active?: boolean
   hash?: string
   team?: string
   username?: string


### PR DESCRIPTION
Allows admin users to add new teams and edit existing teams from within the teams page. Unlike the user table, all changes occur within the table itself. To do so I:
- Added a team-update lambda
- Update the teams table to enable adding/editing
- Given that the changes occur within the table, I moved the `+ New User` button within the table component and handle all the updates with React state.

Also of note, I change the create and update teams lambdas to return the full list of team on success. This makes updating the table a bit easier after save.

I did add a popup error if the request fails, Some refinement may be necessary with regard to validation and error handling. It may also be wise to implement a saving state to prevent users from attempting to submit additional edit requests before the initial one resolves.