### PR TITLE
Feature - Update Guest Users

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -16,6 +16,7 @@
   "words": [
     "Aprimo",
     "funcs",
+    "querystrings",
     "somepage"
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,13 @@ EVENT_UPLOAD_METADATA = ./config/sim-events/upload-metadata.json
 build:
 	cd web; npm i && npm run build;
 	cd serverless;\
+<<<<<<< HEAD
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-create funcs/admin-create/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admins-get funcs/admins-get/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-get funcs/admin-get/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guest-auth funcs/guest-auth/*.go;\
+	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guest-get funcs/guest-get/*.go;\
+	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guest-update funcs/guest-update/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guests-get funcs/guests-get/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/init-db funcs/init-db/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/creds-salt funcs/creds-salt/*.go;\

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ EVENT_UPLOAD_METADATA = ./config/sim-events/upload-metadata.json
 build:
 	cd web; npm i && npm run build;
 	cd serverless;\
-<<<<<<< HEAD
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-create funcs/admin-create/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admins-get funcs/admins-get/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-get funcs/admin-get/*.go;\

--- a/serverless/config/sim-events/team-create.json
+++ b/serverless/config/sim-events/team-create.json
@@ -1,3 +1,3 @@
 {
-  "body": "{\"team\": \"Team Super Cool\"}"
+  "body": "{\"teamName\": \"Team Super Cool\"}"
 }

--- a/serverless/funcs/guest-get/main.go
+++ b/serverless/funcs/guest-get/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/IIP-Design/commons-gateway/utils/data/data"
+	"github.com/IIP-Design/commons-gateway/utils/data/guests"
+	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// GetGuestHandler handles the request to retrieve a single admin user based on email address.
+func GetGuestHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
+	id := event.QueryStringParameters["id"]
+
+	if id == "" {
+		return msgs.SendServerError(errors.New("user id not provided"))
+	}
+
+	// Ensure the user exists doesn't already have access.
+	exists, err := data.CheckForExistingUser(id, "guests")
+
+	if err != nil || !exists {
+		return msgs.SendServerError(errors.New("user does not exist"))
+	}
+
+	guest, err := guests.RetrieveGuest(id)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	body, err := msgs.MarshalBody(guest)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	return msgs.PrepareResponse(body)
+}
+
+func main() {
+	lambda.Start(GetGuestHandler)
+}

--- a/serverless/funcs/guest-update/main.go
+++ b/serverless/funcs/guest-update/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/IIP-Design/commons-gateway/utils/data/data"
+	"github.com/IIP-Design/commons-gateway/utils/data/guests"
+	"github.com/IIP-Design/commons-gateway/utils/data/teams"
+	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// GuestUpdateHandler handles the request to edit an existing guest user.
+// It ensures that the required data is present before continuing on to
+// update the team data.
+func GuestUpdateHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
+	guest, err := data.ExtractGuestUser(event.Body)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	// Ensure that the user we intend to modify exists.
+	userExists, err := data.CheckForExistingUser(guest.Email, "guests")
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	} else if !userExists {
+		return msgs.SendServerError(errors.New("this user has not been registered"))
+	}
+
+	// Ensure that the user's assigned team exists.
+	exists, err := teams.CheckForExistingTeamById(guest.Team)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	} else if !exists {
+		return msgs.SendServerError(errors.New("no team with the provided id exists"))
+	}
+
+	err = guests.UpdateGuest(guest)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	return msgs.SendSuccessMessage()
+}
+
+func main() {
+	lambda.Start(GuestUpdateHandler)
+}

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -117,6 +117,23 @@ functions:
     package:
       patterns:
         - './bin/guest-auth'
+  guestGet:
+    name: gateway-${opt:stage}-guest-get
+    handler: bin/guest-get
+    description: Retrieve a single guest users.
+    runtime: go1.x
+    events:
+      - http:
+          path: /guest
+          method: get
+          request:
+            parameters:
+              querystrings:
+                id: true
+          cors: ${file(./config/${param:deployment}.json):cors}
+    package:
+      patterns:
+        - './bin/guest-get'
   guestsGet:
     name: gateway-${opt:stage}-guests-get
     handler: bin/guests-get

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -134,6 +134,19 @@ functions:
     package:
       patterns:
         - './bin/guest-get'
+  guestUpdate:
+    name: gateway-${opt:stage}-guest-update
+    handler: bin/guest-update
+    description: Update a guest users.
+    runtime: go1.x
+    events:
+      - http:
+          path: /guest/update
+          method: post
+          cors: ${file(./config/${param:deployment}.json):cors}
+    package:
+      patterns:
+        - './bin/guest-update'
   guestsGet:
     name: gateway-${opt:stage}-guests-get
     handler: bin/guests-get

--- a/serverless/utils/data/data/parser.go
+++ b/serverless/utils/data/data/parser.go
@@ -79,27 +79,58 @@ func ParseBodyData(body string) (RequestBodyOptions, error) {
 // ExtractUser parses an API Gateway request body returning the data
 // need to create a new user.
 func ExtractUser(body string) (User, error) {
-	var admin User
+	var user User
 
 	parsed, err := ParseBodyData(body)
 
-	adminEmail := parsed.Email
+	email := parsed.Email
 	firstName := parsed.NameFirst
 	lastName := parsed.NameLast
 	team := parsed.TeamId
 
 	if err != nil {
-		return admin, err
-	} else if adminEmail == "" || firstName == "" || lastName == "" || team == "" {
-		return admin, errors.New("data missing from request")
+		return user, err
+	} else if email == "" || firstName == "" || lastName == "" || team == "" {
+		return user, errors.New("data missing from request")
 	}
 
-	admin.Email = adminEmail
-	admin.NameFirst = firstName
-	admin.NameLast = lastName
-	admin.Team = team
+	user.Email = email
+	user.NameFirst = firstName
+	user.NameLast = lastName
+	user.Team = team
 
-	return admin, err
+	return user, err
+}
+
+// ExtractGuestUser parses an API Gateway request body returning the data
+// need to modify an existing guest user.
+func ExtractGuestUser(body string) (GuestUser, error) {
+	var guest GuestUser
+
+	userData, err := ExtractUser(body)
+
+	if err != nil {
+		return guest, err
+	}
+
+	guest.Email = userData.Email
+	guest.NameFirst = userData.NameFirst
+	guest.NameLast = userData.NameLast
+	guest.Team = userData.Team
+
+	parsed, err := ParseBodyData(body)
+
+	expiration := parsed.Expires
+
+	if err != nil {
+		return guest, err
+	} else if expiration == "" {
+		return guest, errors.New("expiration data missing from request")
+	}
+
+	guest.Expires = expiration
+
+	return guest, err
 }
 
 // ExtractInvite parses an API Gateway request body returning the data

--- a/serverless/utils/data/guests/guests.go
+++ b/serverless/utils/data/guests/guests.go
@@ -1,31 +1,59 @@
 package guests
 
 import (
-	"fmt"
+	"database/sql"
+	"time"
 
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
 	"github.com/IIP-Design/commons-gateway/utils/logs"
 )
+
+func RetrieveGuest(email string) (map[string]string, error) {
+	var guest map[string]string
+
+	pool := data.ConnectToDB()
+	defer pool.Close()
+
+	var firstName string
+	var lastName string
+	var team string
+	var expiration time.Time
+
+	query := `SELECT first_name, last_name, team, expiration FROM guests WHERE email = $1`
+	err := pool.QueryRow(query, email).Scan(&firstName, &lastName, &team, &expiration)
+
+	if err != nil {
+		logs.LogError(err, "Retrieve Guest Query Error")
+	}
+
+	guest = map[string]string{
+		"email":      email,
+		"givenName":  firstName,
+		"familyName": lastName,
+		"team":       team,
+		"expiration": expiration.String(),
+	}
+
+	return guest, err
+}
 
 // RetrieveGuests opens a database connection and retrieves the full list of admin users.
 func RetrieveGuests(team string) ([]map[string]string, error) {
 	var guests []map[string]string
 	var err error
 	var query string
+	var rows *sql.Rows
 
 	pool := data.ConnectToDB()
 	defer pool.Close()
 
 	if team == "" {
 		query = `SELECT email, first_name, last_name, team, expiration FROM guests`
+		rows, err = pool.Query(query)
 	} else {
-		query = fmt.Sprintf(
-			`SELECT email, first_name, last_name, team, expiration FROM guests WHERE team = '%s';`,
-			team,
-		)
+		query = `SELECT email, first_name, last_name, team, expiration FROM guests WHERE team = $1;`
+		rows, err = pool.Query(query, team)
 	}
-
-	rows, err := pool.Query(query)
 
 	if err != nil {
 		logs.LogError(err, "Get Guests Query Error")

--- a/serverless/utils/data/guests/guests.go
+++ b/serverless/utils/data/guests/guests.go
@@ -8,6 +8,7 @@ import (
 	"github.com/IIP-Design/commons-gateway/utils/logs"
 )
 
+// RetrieveGuest opens a database connection and retrieves the information for a single user.
 func RetrieveGuest(email string) (map[string]string, error) {
 	var guest map[string]string
 
@@ -48,10 +49,12 @@ func RetrieveGuests(team string) ([]map[string]string, error) {
 	defer pool.Close()
 
 	if team == "" {
-		query = `SELECT email, first_name, last_name, team, expiration FROM guests`
+		query = `SELECT email, first_name, last_name, team, expiration FROM guests ORDER BY first_name;`
 		rows, err = pool.Query(query)
 	} else {
-		query = `SELECT email, first_name, last_name, team, expiration FROM guests WHERE team = $1;`
+		query =
+			`SELECT email, first_name, last_name, team, expiration
+			 FROM guests WHERE team = $1 ORDER BY first_name;`
 		rows, err = pool.Query(query, team)
 	}
 

--- a/serverless/utils/data/guests/guests.go
+++ b/serverless/utils/data/guests/guests.go
@@ -90,3 +90,23 @@ func RetrieveGuests(team string) ([]map[string]string, error) {
 
 	return guests, err
 }
+
+// UpdateGuest opens a database connection and updates a given
+// guest user with the provided information.
+// TODO? - Allow for changes to user email? If so we may need
+// to add an id field and set that as the primary key on a guest.
+func UpdateGuest(guest data.GuestUser) error {
+	pool := data.ConnectToDB()
+	defer pool.Close()
+
+	query :=
+		`UPDATE guests SET first_name = $1, last_name = $2, team = $3,
+		 expiration = $4 WHERE email = $5`
+	_, err := pool.Exec(query, guest.NameFirst, guest.NameLast, guest.Team, guest.Expires, guest.Email)
+
+	if err != nil {
+		logs.LogError(err, "Update Guest Query Error")
+	}
+
+	return err
+}

--- a/serverless/utils/data/teams/teams.go
+++ b/serverless/utils/data/teams/teams.go
@@ -2,7 +2,6 @@ package teams
 
 import (
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
@@ -21,8 +20,8 @@ func CheckForExistingTeam(teamName string) (bool, error) {
 
 	var team string
 
-	query := fmt.Sprintf(`SELECT team_name FROM teams WHERE team_name = '%s';`, teamName)
-	err = pool.QueryRow(query).Scan(&team)
+	query := `SELECT team_name FROM teams WHERE team_name = $1;`
+	err = pool.QueryRow(query, teamName).Scan(&team)
 
 	if err != nil {
 		// Do not return an error if no results are found.
@@ -47,8 +46,8 @@ func CheckForExistingTeamById(teamId string) (bool, error) {
 
 	var team string
 
-	query := fmt.Sprintf(`SELECT id FROM teams WHERE id = '%s';`, teamId)
-	err = pool.QueryRow(query).Scan(&team)
+	query := `SELECT id FROM teams WHERE id = $1;`
+	err = pool.QueryRow(query, teamId).Scan(&team)
 
 	if err != nil {
 		// Do not return an error if no results are found.
@@ -91,13 +90,8 @@ func UpdateTeam(teamId string, teamName string, active bool) error {
 	pool := data.ConnectToDB()
 	defer pool.Close()
 
-	query := fmt.Sprintf(
-		`UPDATE teams SET team_name = '%s', active = '%t' WHERE id = '%s';`,
-		teamName,
-		active,
-		teamId,
-	)
-	_, err = pool.Exec(query)
+	query := `UPDATE teams SET team_name = $1, active = $2 WHERE id = $3;`
+	_, err = pool.Exec(query, teamName, active, teamId)
 
 	if err != nil {
 		logs.LogError(err, "Update Team Query Error")
@@ -113,12 +107,8 @@ func UpdateTeamStatus(teamId string, active bool) error {
 	pool := data.ConnectToDB()
 	defer pool.Close()
 
-	query := fmt.Sprintf(
-		`UPDATE teams SET active = '%t' WHERE id = '%s';`,
-		active,
-		teamId,
-	)
-	_, err = pool.Exec(query)
+	query := `UPDATE teams SET active = $1 WHERE id = $2;`
+	_, err = pool.Exec(query, active, teamId)
 
 	if err != nil {
 		logs.LogError(err, "Update Team Status Query Error")

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -40,8 +40,9 @@ const currentPath = pathname.replaceAll('/', '');
     display: none;
     margin: 0;
 
-    a {
-      padding: 1rem 0 0;
+    a,
+    a:visited {
+      padding: 0.5rem;
       text-decoration: none;
       font-size: 1rem;
       font-weight: bold;

--- a/web/src/components/UserForm.tsx
+++ b/web/src/components/UserForm.tsx
@@ -43,11 +43,6 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
   const [teamList, setTeamList] = useState( [] );
   const [userData, setUserData] = useState<IUserFormData>( initialState );
 
-  // Reset the form fields
-  const clear = () => {
-    setUserData( initialState );
-  };
-
   // Check whether the user is an admin and set that value in state.
   // Doing so outside of a useEffect hook causes a mismatch in values
   // between the statically rendered portion and the client.
@@ -72,7 +67,7 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
     getTeams();
   }, [isAdmin] );
 
-  // Clear the input fields.
+  // Initialize the form.
   useEffect( () => {
     const getUser = async ( id: string ) => {
       const response = await buildQuery( `guest?id=${id}`, null, 'GET' );
@@ -87,8 +82,6 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
       }
     };
 
-    clear();
-
     if ( user ) {
       const urlSearchParams = new URLSearchParams( window.location.search );
       const { id } = Object.fromEntries( urlSearchParams.entries() );
@@ -97,6 +90,10 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
     }
   }, [user] );
 
+  /**
+   * Updates the user state on changed to the form inputs.
+   * @param key The user property being updated.
+   */
   const handleUpdate = ( key: keyof IUserFormData, value?: string|Date ) => {
     setUserData( { ...userData, [key]: value } );
   };
@@ -123,6 +120,10 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
     return true;
   };
 
+  /**
+   * Validates the form inputs and sends the provided data to the API.
+   * @param e The submission event - simply used to prevent the default page refresh.
+   */
   const handleSubmit = async ( e: FormEvent<HTMLFormElement> ) => {
     e.preventDefault();
 
@@ -138,7 +139,7 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
         familyName: userData.familyName,
         team: userData.team || currentUser.get().team,
       },
-      expiration: new Date( userData.accessEndDate as string ).toISOString(), // Conversion to iso required by Lambda
+      expiration: new Date( userData.accessEndDate ).toISOString(), // Conversion to iso required by Lambda
     };
 
     await buildQuery( 'creds/provision', invitation, 'POST' )

--- a/web/src/components/UserTable.tsx
+++ b/web/src/components/UserTable.tsx
@@ -121,7 +121,9 @@ const UserTable: FC = () => {
             { userList && ( userList.map( user => (
               <tr key={ user.email }>
                 <td>
-                  { `${user.givenName} ${user.familyName}` }
+                  <a href={ `/user?id=${user.email}` }>
+                    { `${user.givenName} ${user.familyName}` }
+                  </a>
                 </td>
                 <td>{ user.email }</td>
                 <td>{ getTeamName( user.team, teams ) }</td>

--- a/web/src/components/UserTable.tsx
+++ b/web/src/components/UserTable.tsx
@@ -121,7 +121,7 @@ const UserTable: FC = () => {
             { userList && ( userList.map( user => (
               <tr key={ user.email }>
                 <td>
-                  <a href={ `/user?id=${user.email}` }>
+                  <a href={ `/user?id=${user.email}` } style={ { padding: '0.3rem' } }>
                     { `${user.givenName} ${user.familyName}` }
                   </a>
                 </td>

--- a/web/src/components/UserTable.tsx
+++ b/web/src/components/UserTable.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import type { FC } from 'react';
 
 import { buildQuery } from '../utils/api';
+import currentUser from '../stores/current-user';
 import { isGuestActive } from '../utils/guest';
 import { getTeamName } from '../utils/team';
 import { selectSlice } from '../utils/arrays';
@@ -21,8 +22,10 @@ const UserTable: FC = () => {
   const [teams, setTeams] = useState( [] );
 
   useEffect( () => {
+    const body = currentUser.get().isAdmin === 'true' ? {} : { team: currentUser.get().team };
+
     const getUsers = async () => {
-      const response = await buildQuery( 'guests', { team: 'cjjlml77k98c70bm73pg' } );
+      const response = await buildQuery( 'guests', body );
       const { data } = await response.json();
 
       if ( data ) {

--- a/web/src/pages/newuser.astro
+++ b/web/src/pages/newuser.astro
@@ -2,7 +2,6 @@
 import AdminPageLayout from '../layouts/AdminPageLayout.astro';
 import PageContainer from '../layouts/PageContainer.astro';
 import UserForm from '../components/UserForm';
-import currentUser from '../stores/current-user';
 
 const title = 'New User';
 ---

--- a/web/src/pages/user.astro
+++ b/web/src/pages/user.astro
@@ -2,13 +2,12 @@
 import AdminPageLayout from '../layouts/AdminPageLayout.astro';
 import PageContainer from '../layouts/PageContainer.astro';
 import UserForm from '../components/UserForm';
-import currentUser from '../stores/current-user';
 
-const title = 'New User';
+const title = 'Edit User';
 ---
 
 <AdminPageLayout title={title}>
   <PageContainer narrow title={title}>
-    <UserForm client:load />
+    <UserForm client:load user />
   </PageContainer>
 </AdminPageLayout>

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -2,7 +2,7 @@
 
 :root {
   --blue: #0a2240;
-  --blueLight: #0086c9;
+  --blueLight: #3474DA;
   --grey: #8c8c8c;
   --greyLight: #dadada;
   --greyLighter: #f5f5f5;
@@ -38,6 +38,18 @@
 * + * {
   margin: 0;
   padding: 0;
+}
+
+a,
+a:visited {
+  color: var(--blueLight);
+}
+
+button:focus-visible,
+a:focus-visible {
+  border-radius: 5px;
+  outline: 3px solid var(--blueLight);
+  outline-offset: 1px;
 }
 
 body {

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -8,6 +8,7 @@ type TMethods = 'GET' | 'POST';
 interface IFetchBody {
   action?: TActions
   active?: boolean
+  expiration?: string
   hash?: string
   team?: string
   teamName?: string

--- a/web/src/utils/dates.ts
+++ b/web/src/utils/dates.ts
@@ -1,3 +1,7 @@
+import { isAfter, isBefore, addDays, parse } from 'date-fns';
+
+import { MAX_ACCESS_GRANT_DAYS } from './constants';
+
 /**
  * Converts any date to a string in the `YYYY-MM-DD` format
  * @param date The date to be transformed.
@@ -20,4 +24,15 @@ export const addDaysToNow = ( days: number ) => {
   const future = new Date( now ).setDate( now.getDate() + days );
 
   return new Date( future );
+};
+
+/**
+ * Checks whether a given date falls after the present and before max grant days.
+ * @param dateStr A provided date string.
+ */
+export const dateSelectionIsValid = ( dateStr?: string ) => {
+  const now = new Date();
+  const date = parse( dateStr || '', 'yyyy-MM-dd', new Date() );
+
+  return date && isAfter( date, now ) && isBefore( date, addDays( now, MAX_ACCESS_GRANT_DAYS ) );
 };


### PR DESCRIPTION
Enable the editing of existing guest users. Namely:
- Adds a Lambda to retrieve a single guest user's information
- Adds a Lambda to update a guest user
- Adds a `user` page to display the user form
- Renames the `NewUser` component `UserForm` and uses it both when adding and editing a guest user. Some things to note here are the restriction on setting the user's team when not an admin and the restriction on updating an existing user's email (since we use that as the id value).
- In `UserTable` only retrieve the guest users for the current user's team, unless the current user is an admin.

Additionally, replaces some string interpolated queries with parameterized queries to prevent SQL injections (for example in `serverless/utils/data/teams/teams.go`).

Makes some small, incidental changes to link and button focus styles.