### PR TITLE
Cloudformation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ clean:
 	cd ../web; rm -rf dist;
 
 deploy: clean build
-	aws s3 cp ./web/dist s3://$(STAGE).gateway.gpalab.digital/ --recursive;\
-	cd serverless; npm run sls -- deploy --stage $(STAGE) --verbose;
+	cd serverless; npm run sls -- deploy --stage $(STAGE) --verbose;\
+	aws s3 cp ./web/dist s3://$(STAGE)-gateway.gpalab.digital/ --recursive;
 
 dev:
 	cd $(DEV_DIR); docker-compose up -d

--- a/serverless/config/dev.json
+++ b/serverless/config/dev.json
@@ -1,7 +1,7 @@
 {
   "allowedOrigins": "*",
   "cors": {
-    "origins": ["http://localhost:3000", "http://*.gpalab.digital"],
+    "origins": ["http://localhost:3000", "https://*.gpalab.digital"],
     "headers": [
       "Content-Type",
       "X-Amz-Date",

--- a/serverless/config/resources/cloudfront.yml
+++ b/serverless/config/resources/cloudfront.yml
@@ -1,0 +1,106 @@
+Resources:
+  CloudFrontCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Comment: Determines the caching behavior for the commons gateway static site
+        DefaultTTL: 0
+        MaxTTL: 0
+        MinTTL: 0
+        Name: commons-gateway-${opt:stage}-web
+        ParametersInCacheKeyAndForwardedToOrigin:
+          CookiesConfig:
+            CookieBehavior: none
+          EnableAcceptEncodingBrotli: false
+          EnableAcceptEncodingGzip: false
+          HeadersConfig:
+            HeaderBehavior: none
+          QueryStringsConfig:
+            QueryStringBehavior: none
+
+  CloudFrontOriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Description: Used by CloudFront to access the static site bucket.
+        Name: CommonsGatewayOriginAccessControl-${opt:stage}
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  # Allows the use of index.html files in subdirectories
+  CloudFrontFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      AutoPublish: true
+      FunctionCode: |
+        function handler(event) {
+          var request = event.request;
+          var uri = request.uri;
+          
+          // Check whether the URI is missing a file name.
+          if (uri.endsWith('/')) {
+            request.uri += 'index.html';
+          } 
+          // Check whether the URI is missing a file extension.
+          else if (!uri.includes('.')) {
+            request.uri += '/index.html';
+          }
+
+          return request;
+        }
+      FunctionConfig:
+        Comment: Redirect to index files in subdirectories
+        Runtime: cloudfront-js-1.0
+      Name: commons-gateway-${opt:stage}-index-redirect
+
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Comment: Points to the S3 bucket hosting the Commons Gateway static site.
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+          CachedMethods:
+            - GET
+            - HEAD
+          CachePolicyId: !Ref CloudFrontCachePolicy
+          Compress: true
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt CloudFrontFunction.FunctionARN
+          TargetOriginId: commons-gateway-${opt:stage}
+          ViewerProtocolPolicy: redirect-to-https
+        DefaultRootObject: index.html
+        Enabled: true
+        HttpVersion: http2
+        Origins:
+          - DomainName: !GetAtt StaticSiteBucket.RegionalDomainName
+            Id: commons-gateway-${opt:stage}
+            OriginAccessControlId: !GetAtt CloudFrontOriginAccessControl.Id
+            OriginShield:
+              Enabled: false
+            S3OriginConfig:
+              OriginAccessIdentity: '' # Required when using Origin Access Control
+
+  CloudFrontS3BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref StaticSiteBucket
+      PolicyDocument:
+        Version: '2008-10-17'
+        Statement:
+          - Effect: Allow
+            Action: s3:GetObject
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Resource: arn:aws:s3:::commons-gateway-${opt:stage}-web/*
+            Sid: AllowCloudFrontServicePrincipal
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Join
+                  - ''
+                  - - arn:aws:cloudfront::${aws:accountId}:distribution/
+                    - !Ref CloudFrontDistribution

--- a/serverless/config/resources/s3.yml
+++ b/serverless/config/resources/s3.yml
@@ -1,0 +1,10 @@
+Resources:
+  UploadBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: commons-gateway-${opt:stage}-upload
+
+  CleanBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: commons-gateway-${opt:stage}-clean

--- a/serverless/config/resources/s3.yml
+++ b/serverless/config/resources/s3.yml
@@ -1,10 +1,21 @@
 Resources:
+  # Target bucket for user uploads - scanned by ClamAV.
   UploadBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: commons-gateway-${opt:stage}-upload
 
+  # Bucket where successfully scanned files end up.
   CleanBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: commons-gateway-${opt:stage}-clean
+
+  # Bucket from which static site is served.
+  StaticSiteBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: commons-gateway-${opt:stage}-web
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: 404.html

--- a/serverless/config/resources/vpc.yml
+++ b/serverless/config/resources/vpc.yml
@@ -3,6 +3,9 @@ Resources:
     Type: AWS::EC2::VPC
     Properties:
       CidrBlock: ${self:custom.CIDR}
+      Tags:
+        - Key: Name
+          Value: commons-gateway-vpc-${opt:stage}
 
   SubnetA:
     Type: AWS::EC2::Subnet
@@ -10,6 +13,9 @@ Resources:
       VpcId: !Ref VPC
       AvailabilityZone: ${aws:region}a
       CidrBlock: 10.0.0.0/24
+      Tags:
+        - Key: Name
+          Value: commons-gateway-${opt:stage}-subnet-a
 
   SubnetB:
     Type: AWS::EC2::Subnet
@@ -17,22 +23,31 @@ Resources:
       VpcId: !Ref VPC
       AvailabilityZone: ${aws:region}b
       CidrBlock: 10.0.1.0/24
+      Tags:
+        - Key: Name
+          Value: commons-gateway-${opt:stage}-subnet-b
 
   LambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref VPC
-      GroupName: commons-gateway-${opt:stage}-lambdas
-      GroupDescription: Commons Gateway Lambda functions security group
+      GroupName: commons-gateway-${opt:stage}-sg-lambdas
+      GroupDescription: Enables outgoing internet access for Lambdas within the VPC
+      Tags:
+        - Key: Name
+          Value: commons-gateway-${opt:stage}-lambdas
 
   RDSSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref VPC
-      GroupName: commons-gateway-${opt:stage}-rds
-      GroupDescription: Commons Gateway RDS security group
+      GroupName: commons-gateway-${opt:stage}-sg-rds
+      GroupDescription: Grants access to the RDS instance used by the Commons Gateway
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 0
           ToPort: 65535
           CidrIp: ${self:custom.CIDR}
+      Tags:
+        - Key: Name
+          Value: commons-gateway-${opt:stage}-rds

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -52,6 +52,7 @@ resources:
   - ${file(./config/resources/vpc.yml)}
   - ${file(./config/resources/rds.yml)}
   - ${file(./config/resources/proxy.yml)}
+  - ${file(./config/resources/s3.yml)}
 
 # Defines how the functions are deployed. To reduce the functions
 # size for each Lambda, we package them independently. This requires
@@ -274,7 +275,7 @@ functions:
       patterns:
         - 'funcs/upload-presigned-url/dist/index.cjs'
     environment:
-      S3_UPLOAD_BUCKET: s3uploader-s3uploadbucket-8qfrclyi5f2f # TODO - Parameterize
+      S3_UPLOAD_BUCKET: commons-gateway-${opt:stage}-upload
   email2fa:
     name: gateway-${opt:stage}-email-2fa
     handler: funcs/email-2fa/dist/index.handler

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -10,7 +10,7 @@ plugins:
 params:
   default:
     deployment: dev
-    rollback: true
+    rollback: false
   prod:
     deployment: prod
     rollback: false
@@ -71,8 +71,7 @@ functions:
       - http:
           path: /admin/create
           method: post
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/admin-create'
@@ -85,8 +84,7 @@ functions:
       - http:
           path: /admin/get
           method: post
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/admin-get'
@@ -99,8 +97,7 @@ functions:
       - http:
           path: /admins
           method: get
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/admins-get'
@@ -113,8 +110,7 @@ functions:
       - http:
           path: /guest/auth
           method: post
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/guest-auth'
@@ -174,8 +170,7 @@ functions:
       - http:
           path: /guests
           method: post
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/guests-get'
@@ -196,8 +191,7 @@ functions:
       - http:
           path: /team/create
           method: post
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/team-create'
@@ -236,8 +230,7 @@ functions:
       - http:
           path: /creds/salt
           method: post
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/creds-salt'
@@ -250,8 +243,7 @@ functions:
       - http:
           path: /creds/provision
           method: post
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/creds-provision'
@@ -264,8 +256,7 @@ functions:
       - http:
           path: /upload
           method: post
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - './bin/upload-metadata'
@@ -278,8 +269,7 @@ functions:
       - http:
           path: /upload
           method: get
-          cors:
-            origin: ${file(./config/${param:deployment}.json):allowedOrigins}
+          cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:
         - 'funcs/upload-presigned-url/dist/index.cjs'

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -57,6 +57,7 @@ resources:
   - ${file(./config/resources/rds.yml)}
   - ${file(./config/resources/proxy.yml)}
   - ${file(./config/resources/s3.yml)}
+  - ${file(./config/resources/cloudfront.yml)}
 
 # Defines how the functions are deployed. To reduce the functions
 # size for each Lambda, we package them independently. This requires

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -23,8 +23,12 @@ provider:
       name: CommonsGatewayLambdaRole-${opt:stage}
       statements:
         - Effect: Allow
-          Action: 'rds-db:connect'
-          Resource: !GetAtt RDSProxy.DBProxyArn
+          Action: rds-db:connect
+          Resource: !Join
+            - ''
+            - - 'arn:aws:rds-db:${aws:region}:${aws:accountId}:dbuser:'
+              - !Select [6, !Split [':', !GetAtt RDSProxy.DBProxyArn]]
+              - /*
   vpc:
     securityGroupIds:
       - !Ref LambdaSecurityGroup


### PR DESCRIPTION
Updates the CloudFormation templates deployed by serverless to further automate the infrastructure build. This PR:

- Creates a bucket to store the file uploads from the application. This will be the target bucket for ClamAV scanning. This change may be a bit disruptive to you if you already have files uploaded to a different bucket.
- Creates a bucket to host the static site files.
- Adds a CloudFront distribution to serve the static files. This will NOT automatically enable accessing the production builds remotely, but that is just a few clicks away.
- Adds tags and names to several of the previously un-named infrastructure items to improve visibility and clarity in the AWS console.

**Note:** Renaming some of the items caused some hiccups in the CloudFormation deployments, particularly on the clean up steps where old resources were unable to be deleted. I don't think this is a huge problem, but let me know if it causes any issues.