### PR TITLE
Admins page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean:
 
 deploy: clean build
 	cd serverless; npm run sls -- deploy --stage $(STAGE) --verbose;\
-	aws s3 cp ./web/dist s3://commons-gateway-$(STAGE)-web/ --recursive;
+	aws s3 cp ../web/dist s3://commons-gateway-$(STAGE)-web/ --recursive;
 
 dev:
 	cd $(DEV_DIR); docker-compose up -d

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ build:
 	cd web; npm i && npm run build;
 	cd serverless;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-create funcs/admin-create/*.go;\
-	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admins-get funcs/admins-get/*.go;\
+	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-deactivate funcs/admin-deactivate/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-get funcs/admin-get/*.go;\
+	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admins-get funcs/admins-get/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guest-auth funcs/guest-auth/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guest-deactivate funcs/guest-deactivate/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guest-get funcs/guest-get/*.go;\

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ build:
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-create funcs/admin-create/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-deactivate funcs/admin-deactivate/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-get funcs/admin-get/*.go;\
+	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admin-update funcs/admin-update/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/admins-get funcs/admins-get/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guest-auth funcs/guest-auth/*.go;\
 	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/guest-deactivate funcs/guest-deactivate/*.go;\

--- a/serverless/funcs/admin-deactivate/main.go
+++ b/serverless/funcs/admin-deactivate/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/IIP-Design/commons-gateway/utils/data/data"
+	"github.com/IIP-Design/commons-gateway/utils/logs"
+	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// deactivateAdmin sets an existing admin's `active` status to `false`.
+func deactivateAdmin(email string) error {
+	pool := data.ConnectToDB()
+	defer pool.Close()
+
+	currentTime := time.Now()
+
+	query := `UPDATE admins SET active = false, date_modified = $1 WHERE email = $2`
+	_, err := pool.Exec(query, currentTime, email)
+
+	if err != nil {
+		logs.LogError(err, "Deactivate Admin Query Error")
+	}
+
+	return err
+}
+
+// DeactivateAdminHandler handles the request to deactivate an existing admin.
+// It ensures that the required data is present before continuing on to update the admin data.
+func DeactivateAdminHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
+	username := event.QueryStringParameters["username"]
+
+	if username == "" {
+		return msgs.SendServerError(errors.New("admin id not provided"))
+	}
+
+	// Ensure that the user we intend to modify exists.
+	exists, err := data.CheckForExistingUser(username, "admins")
+
+	if err != nil || !exists {
+		return msgs.SendServerError(errors.New("admin does not exist"))
+	}
+
+	err = deactivateAdmin(username)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	return msgs.SendSuccessMessage()
+}
+
+func main() {
+	lambda.Start(DeactivateAdminHandler)
+}

--- a/serverless/funcs/admin-get/main.go
+++ b/serverless/funcs/admin-get/main.go
@@ -14,18 +14,17 @@ import (
 
 // GetAdminHandler handles the request to retrieve a single admin user based on email address.
 func GetAdminHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
-	parsed, err := data.ParseBodyData(event.Body)
+	username := event.QueryStringParameters["username"]
 
-	if err != nil {
-		return msgs.SendServerError(err)
+	if username == "" {
+		return msgs.SendServerError(errors.New("user name not provided"))
 	}
 
-	username := parsed.Username
+	// Ensure the user exists doesn't already have access.
+	exists, err := data.CheckForExistingUser(username, "admins")
 
-	active, err := admins.CheckForActiveAdmin(username)
-
-	if err != nil || !active {
-		return msgs.SendServerError(errors.New("user not and active admin"))
+	if err != nil || !exists {
+		return msgs.SendServerError(errors.New("user is not an admin"))
 	}
 
 	admin, err := admins.RetrieveAdmin(username)

--- a/serverless/funcs/admin-update/main.go
+++ b/serverless/funcs/admin-update/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/IIP-Design/commons-gateway/utils/data/admins"
+	"github.com/IIP-Design/commons-gateway/utils/data/data"
+	"github.com/IIP-Design/commons-gateway/utils/data/teams"
+	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// UpdateAdminHandler handles the request to edit an existing admin user.
+// It ensures that the required data is present before continuing on to
+// update the team data.
+func UpdateAdminHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
+	admin, err := data.ExtractAdminUser(event.Body)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	// Ensure that the user we intend to modify exists.
+	adminExists, err := data.CheckForExistingUser(admin.Email, "admins")
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	} else if !adminExists {
+		return msgs.SendServerError(errors.New("this admin has not been registered"))
+	}
+
+	// Ensure that the user's assigned team exists.
+	exists, err := teams.CheckForExistingTeamById(admin.Team)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	} else if !exists {
+		return msgs.SendServerError(errors.New("no team with the provided id exists"))
+	}
+
+	err = admins.UpdateAdmin(admin)
+
+	if err != nil {
+		return msgs.SendServerError(err)
+	}
+
+	return msgs.SendSuccessMessage()
+}
+
+func main() {
+	lambda.Start(UpdateAdminHandler)
+}

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -84,12 +84,12 @@ functions:
   adminGet:
     name: gateway-${opt:stage}-admin-get
     handler: bin/admin-get
-    description: Retrieve an individual admin users.
+    description: Retrieve an individual admin user.
     runtime: go1.x
     events:
       - http:
-          path: /admin/get
-          method: post
+          path: /admin
+          method: get
           cors: ${file(./config/${param:deployment}.json):cors}
     package:
       patterns:

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -98,6 +98,19 @@ functions:
     package:
       patterns:
         - './bin/admin-deactivate'
+  adminUpdate:
+    name: gateway-${opt:stage}-admin-update
+    handler: bin/admin-update
+    description: Update a admin users.
+    runtime: go1.x
+    events:
+      - http:
+          path: /admin
+          method: put
+          cors: ${file(./config/${param:deployment}.json):cors}
+    package:
+      patterns:
+        - './bin/admin-update'
   adminGet:
     name: gateway-${opt:stage}-admin-get
     handler: bin/admin-get

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -81,6 +81,23 @@ functions:
     package:
       patterns:
         - './bin/admin-create'
+  adminDeactivate:
+    name: gateway-${opt:stage}-admin-deactivate
+    handler: bin/admin-deactivate
+    description: Deactivate a single admin user.
+    runtime: go1.x
+    events:
+      - http:
+          path: /admin
+          method: delete
+          request:
+            parameters:
+              querystrings:
+                username: true
+          cors: ${file(./config/${param:deployment}.json):cors}
+    package:
+      patterns:
+        - './bin/admin-deactivate'
   adminGet:
     name: gateway-${opt:stage}-admin-get
     handler: bin/admin-get

--- a/serverless/utils/data/admins/admins.go
+++ b/serverless/utils/data/admins/admins.go
@@ -126,3 +126,25 @@ func RetrieveAdmins() ([]map[string]any, error) {
 
 	return admins, err
 }
+
+// UpdateAdmin opens a database connection and updates a given
+// admin user with the provided information.
+// TODO? - Allow for changes to user email? If so we may need
+// to add an id field and set that as the primary key on an admin.
+func UpdateAdmin(admin data.AdminUser) error {
+	pool := data.ConnectToDB()
+	defer pool.Close()
+
+	currentTime := time.Now()
+
+	query :=
+		`UPDATE admins SET first_name = $1, last_name = $2, role = $3, team = $4,
+		 active = $5, date_modified = $6 WHERE email = $7`
+	_, err := pool.Exec(query, admin.NameFirst, admin.NameLast, admin.Role, admin.Team, admin.Active, currentTime, admin.Email)
+
+	if err != nil {
+		logs.LogError(err, "Update Admin Query Error")
+	}
+
+	return err
+}

--- a/serverless/utils/data/admins/admins.go
+++ b/serverless/utils/data/admins/admins.go
@@ -91,7 +91,7 @@ func RetrieveAdmins() ([]map[string]any, error) {
 	pool := data.ConnectToDB()
 	defer pool.Close()
 
-	rows, err := pool.Query(`SELECT email, first_name, last_name, role, team, active FROM admins`)
+	rows, err := pool.Query(`SELECT email, first_name, last_name, role, team, active FROM admins ORDER BY first_name`)
 
 	if err != nil {
 		logs.LogError(err, "Get Admins Query Error")

--- a/serverless/utils/data/data/parser.go
+++ b/serverless/utils/data/data/parser.go
@@ -111,6 +111,36 @@ func ExtractUser(body string) (User, error) {
 	return user, err
 }
 
+// ExtractAdminUser parses an API Gateway request body returning the data
+// need to modify an existing admin user.
+func ExtractAdminUser(body string) (AdminUser, error) {
+	var admin AdminUser
+
+	userData, err := ExtractUser(body)
+
+	if err != nil {
+		return admin, err
+	}
+
+	admin.Email = userData.Email
+	admin.NameFirst = userData.NameFirst
+	admin.NameLast = userData.NameLast
+	admin.Role = userData.Role
+	admin.Team = userData.Team
+
+	parsed, err := ParseBodyData(body)
+
+	active := parsed.Active
+
+	if err != nil {
+		return admin, err
+	}
+
+	admin.Active = active
+
+	return admin, err
+}
+
 // ExtractGuestUser parses an API Gateway request body returning the data
 // need to modify an existing guest user.
 func ExtractGuestUser(body string) (GuestUser, error) {

--- a/web/src/components/AdminForm.tsx
+++ b/web/src/components/AdminForm.tsx
@@ -1,0 +1,291 @@
+// ////////////////////////////////////////////////////////////////////////////
+// React Imports
+// ////////////////////////////////////////////////////////////////////////////
+import { useEffect, useState } from 'react';
+import type { FC, FormEvent } from 'react';
+
+// ////////////////////////////////////////////////////////////////////////////
+// Local Imports
+// ////////////////////////////////////////////////////////////////////////////
+import BackButton from './BackButton';
+
+import type { TUserRole } from '../stores/current-user';
+import { showConfirm, showError } from '../utils/alert';
+import { buildQuery } from '../utils/api';
+import { userIsAdmin } from '../utils/auth';
+
+// ////////////////////////////////////////////////////////////////////////////
+// Styles and CSS
+// ////////////////////////////////////////////////////////////////////////////
+import '../styles/form.scss';
+import styles from '../styles/button.module.scss';
+
+// ////////////////////////////////////////////////////////////////////////////
+// Interfaces and Types
+// ////////////////////////////////////////////////////////////////////////////
+interface IAdminFormData {
+  givenName: string;
+  familyName: string;
+  email: string;
+  team: string;
+  role: TUserRole;
+  active: boolean;
+}
+
+interface IAdminFormProps {
+  readonly admin?: boolean;
+}
+
+const initialState = {
+  active: true,
+  givenName: '',
+  familyName: '',
+  email: '',
+  team: '',
+  role: 'admin' as TUserRole,
+};
+
+// ////////////////////////////////////////////////////////////////////////////
+// Interface and Implementation
+// ////////////////////////////////////////////////////////////////////////////
+const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
+  const [isAdmin, setIsAdmin] = useState( false );
+  const [teamList, setTeamList] = useState( [] );
+  const [adminData, setAdminData] = useState<IAdminFormData>( initialState );
+
+  // Check whether the user is an admin and set that value in state.
+  // Doing so outside of a useEffect hook causes a mismatch in values
+  // between the statically rendered portion and the client.
+  useEffect( () => {
+    setIsAdmin( userIsAdmin() );
+  }, [] );
+
+  // Generate the teams list.
+  useEffect( () => {
+    const getTeams = async () => {
+      const response = await buildQuery( 'teams', null, 'GET' );
+      const { data } = await response.json();
+
+      if ( data ) {
+        setTeamList( data );
+      }
+    };
+
+    getTeams();
+  }, [] );
+
+  // Initialize the form.
+  useEffect( () => {
+    const getAdmin = async ( username: string ) => {
+      const response = await buildQuery( `admin?username=${username}`, null, 'GET' );
+      const { data } = await response.json();
+
+
+      if ( data ) {
+        setAdminData( {
+          ...data,
+          active: data.active === 'true', // value comes in as a string from lambda
+        } );
+      }
+    };
+
+    if ( admin ) {
+      const urlSearchParams = new URLSearchParams( window.location.search );
+      const { id } = Object.fromEntries( urlSearchParams.entries() );
+
+      getAdmin( id );
+    }
+  }, [admin] );
+
+  /**
+   * Updates the user state on changed to the form inputs.
+   * @param key The user property being updated.
+   */
+  const handleUpdate = ( key: keyof IAdminFormData, value?: string|Date ) => {
+    setAdminData( { ...adminData, [key]: value } );
+  };
+
+  /**
+   * Ensure that the form submissions are valid before sending data to the API.
+   */
+  const validateSubmission = () => {
+    if ( !adminData.email?.match( /^.+@.+$/ ) ) {
+      showError( 'Email address is not valid' );
+
+      return false;
+    } if ( !adminData.team ) {
+      showError( 'Please assign this user to a valid team' );
+
+      return false;
+    }
+
+    return true;
+  };
+
+  /**
+   * Validates the form inputs and sends the provided data to the API.
+   * @param e The submission event - simply used to prevent the default page refresh.
+   */
+  const handleSubmit = async ( e: FormEvent<HTMLFormElement> ) => {
+    e.preventDefault();
+
+    if ( !validateSubmission() ) {
+      return;
+    }
+
+    const newAdmin = {
+      active: adminData.active,
+      email: adminData.email.trim(),
+      givenName: adminData.givenName.trim(),
+      familyName: adminData.familyName.trim(),
+      team: adminData.team,
+      role: adminData.role,
+    };
+
+    if ( admin ) {
+      await buildQuery( `admin?username=${adminData.email}`, { ...newAdmin }, 'PUT' )
+        .then( () => window.location.assign( '/admins' ) )
+        .catch( err => console.error( err ) );
+    } else {
+      await buildQuery( 'admin/create', { ...newAdmin, active: true }, 'POST' )
+        .then( () => window.location.assign( '/admins' ) )
+        .catch( err => console.error( err ) );
+    }
+  };
+
+  const handleDeactivate = async () => {
+    const { email, givenName, familyName } = adminData;
+    const { isConfirmed } = await showConfirm( `Are you sure you want to deactivate ${givenName} ${familyName}?` );
+
+    if ( !isConfirmed ) {
+      return;
+    }
+
+    const { ok } = await buildQuery( `admin?username=${email}`, null, 'DELETE' );
+
+    if ( !ok ) {
+      showError( 'Unable to deactivate user' );
+    } else {
+      window.location.assign( '/admins' );
+    }
+  };
+
+  const handleReactivate = async () => {
+    const { email, givenName, familyName } = adminData;
+    const { isConfirmed } = await showConfirm( `Are you sure you want to reactivate ${givenName} ${familyName}?` );
+
+    if ( !isConfirmed ) {
+      return;
+    }
+
+    await buildQuery( `admin?username=${email}`, { ...adminData, active: true }, 'PUT' )
+      .then( () => window.location.assign( '/admins' ) )
+      .catch( err => {
+        showError( 'Unable to reactivate user' );
+        console.error( err );
+      } );
+  };
+
+  return (
+    <form onSubmit={ handleSubmit }>
+      <div className="field-group">
+        <label>
+          <span>Given (First) Name</span>
+          <input
+            id="given-name-input"
+            type="text"
+            required
+            value={ adminData.givenName }
+            onChange={ e => handleUpdate( 'givenName', e.target.value ) }
+          />
+        </label>
+        <label>
+          <span>Family (Last) Name</span>
+          <input
+            id="family-name-input"
+            type="text"
+            required
+            value={ adminData.familyName }
+            onChange={ e => handleUpdate( 'familyName', e.target.value ) }
+          />
+        </label>
+      </div>
+      <div className="field-group">
+        <label>
+          <span>Email</span>
+          <input
+            id="email-input"
+            type="text"
+            required
+            disabled={ admin } // Email is the primary key for users so we prevent changes for existing admins.
+            value={ adminData.email }
+            onChange={ e => handleUpdate( 'email', e.target.value ) }
+          />
+        </label>
+        <label>
+          <span>Team</span>
+          <select
+            id="team-input"
+            disabled={ !isAdmin }
+            required
+            value={ adminData.team }
+            onChange={ e => handleUpdate( 'team', e.target.value ) }
+          >
+            <option value="">- Select a team -</option>
+            { teamList.map( ( { id, name } ) => <option key={ id } value={ id }>{ name }</option> ) }
+          </select>
+        </label>
+      </div>
+      <div className="field-group">
+        <label>
+          <span>Admin Type</span>
+          <select
+            id="role-input"
+            required
+            value={ adminData.role }
+            onChange={ e => handleUpdate( 'role', e.target.value ) }
+          >
+            <option value="admin">admin</option>
+            <option value="super admin">super admin</option>
+          </select>
+        </label>
+      </div>
+      <div style={ { textAlign: 'center' } }>
+        <button
+          className={ `${styles.btn} ${styles['spaced-btn']}` }
+          id="update-btn"
+          type="submit"
+        >
+          { admin ? 'Update Admin User' : 'Add Admin User' }
+        </button>
+        {
+          admin && adminData.active && (
+            <button
+              className={ `${styles['btn-light']} ${styles['spaced-btn']}` }
+              id="deactivate-btn"
+              type="button"
+              onClick={ handleDeactivate }
+            >
+              Deactivate Admin User
+            </button>
+          )
+        }
+        {
+          admin && !adminData.active && (
+            <button
+              className={ `${styles['btn-light']} ${styles['spaced-btn']}` }
+              id="deactivate-btn"
+              type="button"
+              onClick={ handleReactivate }
+            >
+              Reactivate Admin User
+            </button>
+          )
+        }
+        <BackButton showConfirmDialog />
+      </div>
+    </form>
+  );
+};
+
+export default AdminForm;

--- a/web/src/components/AdminTable.tsx
+++ b/web/src/components/AdminTable.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+import type { FC } from 'react';
+
+import { buildQuery } from '../utils/api';
+import { getTeamName } from '../utils/team';
+import { selectSlice } from '../utils/arrays';
+import { renderCountWidget, setIntermediatePagination } from '../utils/pagination';
+
+import style from '../styles/table.module.scss';
+
+const AdminTable: FC = () => {
+  // Set the high and low ends of the view toggle.
+  const LOW_VIEW = 30;
+  const HIGH_VIEW = 90;
+
+  const [viewCount, setViewCount] = useState( LOW_VIEW );
+  const [viewOffset, setViewOffset] = useState( 0 );
+  const [adminList, setAdminList] = useState( selectSlice( [], viewCount, viewOffset ) );
+  const [adminCount, setAdminCount] = useState( adminList.length ); // eslint-disable-line no-unused-vars, @typescript-eslint/no-unused-vars
+  const [teams, setTeams] = useState( [] );
+
+  useEffect( () => {
+    const getAdmins = async () => {
+      const response = await buildQuery( 'admins', null, 'GET' );
+      const { data } = await response.json();
+
+      if ( data ) {
+        setAdminList( selectSlice( data, viewCount, viewOffset ) );
+        setAdminCount( data.length );
+      }
+    };
+
+    getAdmins();
+  }, [viewCount, viewOffset] );
+
+  useEffect( () => {
+    const getTeams = async () => {
+      const response = await buildQuery( 'teams', null, 'GET' );
+      const { data } = await response.json();
+
+      if ( data ) {
+        setTeams( data );
+      }
+    };
+
+    getTeams();
+  }, [] );
+
+  // How many more users are left to the end of the list.
+  const remainingScroll = adminCount - ( viewCount * viewOffset );
+
+  /**
+   * Advance the table scroll forward or backwards.
+   * @param dir The direction of scroll, positive for forward, negative for back.
+   */
+  const turnPage = ( dir: 1 | -1 ) => {
+    setViewOffset( viewOffset + dir );
+  };
+
+  /**
+   * Advance the table scroll to a give page of results.
+   * @param page The page to navigate to.
+   */
+  const goToPage = ( page: number ) => {
+    setViewOffset( page - 1 ); // Adjustment since offsets start at zero.
+  };
+
+  /**
+   * Toggle the number of items displayed in the table.
+   * @param count How many to show.
+   */
+  const changeViewCount = ( count: number ) => {
+    setViewCount( count );
+    // We reset the offset in case the current
+    // offset * new count is more than total users
+    setViewOffset( 0 );
+  };
+
+  return (
+    <div className={ style.container }>
+      <div>
+        <div className={ style.controls }>
+          <span>{ renderCountWidget( adminCount, viewCount, viewOffset ) }</span>
+          { adminCount > LOW_VIEW && (
+            <div className={ style.count }>
+              <span>View:</span>
+              <button
+                className={ style['pagination-btn'] }
+                onClick={ () => changeViewCount( LOW_VIEW ) }
+                disabled={ viewCount === LOW_VIEW }
+                type="button"
+              >
+                { LOW_VIEW }
+              </button>
+              <span>|</span>
+              <button
+                className={ style['pagination-btn'] }
+                onClick={ () => changeViewCount( HIGH_VIEW ) }
+                disabled={ viewCount === HIGH_VIEW }
+                type="button"
+              >
+                { HIGH_VIEW }
+              </button>
+            </div>
+          ) }
+        </div>
+        <table className={ `${style.table} ${style['user-table']}` }>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Team</th>
+              <th>Role</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            { adminList && ( adminList.map( admin => (
+              <tr key={ admin.email }>
+                <td>
+                  <a href={ `/editAdmin?id=${admin.email}` } style={ { padding: '0.3rem' } }>
+                    { `${admin.givenName} ${admin.familyName}` }
+                  </a>
+                </td>
+                <td>{ admin.email }</td>
+                <td>{ getTeamName( admin.team, teams ) }</td>
+                <td>{ admin.role }</td>
+                <td className={ style.status }>
+                  <span className={ admin.active ? style.active : style.inactive } />
+                  { admin.active ? 'Active' : 'Inactive' }
+                </td>
+              </tr>
+            ) ) ) }
+          </tbody>
+        </table>
+      </div>
+      { viewCount < adminCount && (
+        <div className={ style.pagination }>
+          <button
+            className={ style['pagination-btn'] }
+            type="button"
+            onClick={ () => turnPage( -1 ) }
+            disabled={ viewOffset < 1 }
+          >
+            { '< Prev' }
+          </button>
+          { setIntermediatePagination( adminCount, viewCount ).length >= 3 && (
+            <span className={ style['pagination-intermediate'] }>
+              { setIntermediatePagination( adminCount, viewCount ).map( page => (
+                <button
+                  key={ page }
+                  className={ style['pagination-btn'] }
+                  disabled={ viewOffset + 1 === page }
+                  onClick={ () => goToPage( page ) }
+                  type="button"
+                >
+                  { page }
+                </button>
+              ) ) }
+            </span>
+          ) }
+          <button
+            className={ style['pagination-btn'] }
+            type="button"
+            onClick={ () => turnPage( 1 ) }
+            disabled={ remainingScroll <= viewCount }
+          >
+            { 'Next >' }
+          </button>
+        </div>
+      ) }
+    </div>
+  );
+};
+
+export default AdminTable;

--- a/web/src/components/Header.astro
+++ b/web/src/components/Header.astro
@@ -60,7 +60,12 @@ const { centered } = Astro.props;
 
     &.normal {
       align-items: center;
+      justify-content: space-between;
       padding: 0.5rem;
+
+      @include breakpoint('tablet') {
+        justify-content: flex-start;
+      }
     }
   }
 

--- a/web/src/components/TeamTable.tsx
+++ b/web/src/components/TeamTable.tsx
@@ -26,7 +26,7 @@ const TeamTable: FC = () => {
   const [editing, setEditing] = useState( '' );
   const [newName, setNewName] = useState( '' );
 
-  const [canEdit] = useState( userIsSuperAdmin() );
+  const [canEdit] = useState( userIsSuperAdmin() ); // eslint-disable-line react/hook-use-state
 
   useEffect( () => {
     // Retrieve the full list of teams from the API.
@@ -165,7 +165,7 @@ const TeamTable: FC = () => {
 
   return (
     <div className={ style.container }>
-      { canEdit &&
+      { canEdit && (
         <button
           className={ `${style['add-btn']} ${btnStyle.btn}` }
           type="button"
@@ -173,7 +173,7 @@ const TeamTable: FC = () => {
         >
           + New Team
         </button>
-      }
+      ) }
       <div>
         <div className={ style.controls }>
           <span>{ renderCountWidget( teamCount, viewCount, viewOffset ) }</span>
@@ -210,19 +210,20 @@ const TeamTable: FC = () => {
           <tbody>
             { teamList && ( teamList.map( team => (
               <tr key={ team.id }>
-                { canEdit ?
-                  <td>
-                    { editing === team.id && (
-                      <input style={ { maxWidth: '100%', padding: '0.3rem 0.5rem' } } type="text" value={ newName } onChange={ e => setNewName( e.target.value ) } aria-label="Team Name" />
-                    ) }
-                    { editing !== team.id && (
-                      <button className={ style['pagination-btn'] } disabled={ editing !== '' } style={ { textAlign: 'left' } } type="button" onClick={ () => editTeam( team.id, team.name ) }>
-                        { team.name }
-                      </button>
-                    ) }
-                  </td>
-                  : <td>{ team.name }</td>
-                }
+                { canEdit
+                  ? (
+                    <td>
+                      { editing === team.id && (
+                        <input style={ { maxWidth: '100%', padding: '0.3rem 0.5rem' } } type="text" value={ newName } onChange={ e => setNewName( e.target.value ) } aria-label="Team Name" />
+                      ) }
+                      { editing !== team.id && (
+                        <button className={ style['pagination-btn'] } disabled={ editing !== '' } style={ { textAlign: 'left' } } type="button" onClick={ () => editTeam( team.id, team.name ) }>
+                          { team.name }
+                        </button>
+                      ) }
+                    </td>
+                  )
+                  : <td>{ team.name }</td> }
                 <td>
                   { editing === team.id && (
                     <div className={ btnStyle['btn-pair'] }>
@@ -231,7 +232,12 @@ const TeamTable: FC = () => {
                     </div>
                   ) }
                   { editing !== team.id && (
-                    <ToggleSwitch active={ team.active } callback={handleStatusToggle} toggleable={canEdit} id={ team.id } />
+                    <ToggleSwitch
+                      active={ team.active }
+                      callback={ handleStatusToggle }
+                      id={ team.id }
+                      toggleable={ canEdit }
+                    />
                   ) }
                 </td>
               </tr>

--- a/web/src/components/UserForm.tsx
+++ b/web/src/components/UserForm.tsx
@@ -148,9 +148,9 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
     const expiration = new Date( userData.accessEndDate ).toISOString();
 
     const invitee = {
-      email: userData.email,
-      givenName: userData.givenName,
-      familyName: userData.familyName,
+      email: userData.email.trim(),
+      givenName: userData.givenName.trim(),
+      familyName: userData.familyName.trim(),
       team: userData.team || currentUser.get().team,
       role: userData.role,
     };

--- a/web/src/components/UserForm.tsx
+++ b/web/src/components/UserForm.tsx
@@ -174,18 +174,20 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
 
   const handleDeactivate = async () => {
     const { email, givenName, familyName } = userData;
-    const { isConfirmed } = await showConfirm( `Are you sure you want to deactiate ${givenName} ${familyName}?` );
-    if( !isConfirmed ) {
+    const { isConfirmed } = await showConfirm( `Are you sure you want to deactivate ${givenName} ${familyName}?` );
+
+    if ( !isConfirmed ) {
       return;
     }
 
     const { ok } = await fetch( `${constructUrl( 'guest' )}?id=${email}`, { method: 'DELETE' } );
-    if( !ok ) {
+
+    if ( !ok ) {
       showError( 'Unable to deactivate user' );
     } else {
       window.location.assign( '/' );
     }
-  }
+  };
 
   return (
     <form onSubmit={ handleSubmit }>
@@ -252,22 +254,24 @@ const UserForm: FC<IUserFormProps> = ( { user } ) => {
       </div>
       <div style={ { textAlign: 'center' } }>
         <button
-          className={ `${styles.btn} ${styles["spaced-btn"]}` }
+          className={ `${styles.btn} ${styles['spaced-btn']}` }
           id="update-btn"
           type="submit"
         >
           { user ? 'Update User' : 'Invite User' }
         </button>
         {
-          user ?
-            <button
-              className={ `${styles["btn-light"]} ${styles["spaced-btn"]}` }
-              id="deactivate-btn"
-              type="button"
-              onClick={handleDeactivate}
-            >
-              Deactivate User
-            </button>
+          user
+            ? (
+              <button
+                className={ `${styles['btn-light']} ${styles['spaced-btn']}` }
+                id="deactivate-btn"
+                type="button"
+                onClick={ handleDeactivate }
+              >
+                Deactivate User
+              </button>
+            )
             : null
         }
         <BackButton showConfirmDialog />

--- a/web/src/layouts/TableContainer.astro
+++ b/web/src/layouts/TableContainer.astro
@@ -24,7 +24,7 @@ const { btnHref, btnText, desc, narrow, title } = Astro.props;
   @use '../styles/breakpoints.scss' as *;
 
   .add-btn {
-    transform: translateY(8.4rem);
+    transform: translateY(6rem);
     position: absolute;
     right: 0;
     margin-right: 1rem;

--- a/web/src/pages/admins.astro
+++ b/web/src/pages/admins.astro
@@ -7,7 +7,7 @@ const title = 'Administrative Users';
 ---
 
 <AdminPageLayout title={title}>
-  <TableContainer btnText="+ New Admin" btnHref="newUser" title={title}>
+  <TableContainer btnText="+ New Admin" btnHref="newAdmin" title={title}>
     <AdminTable client:load />
   </TableContainer>
 </AdminPageLayout>

--- a/web/src/pages/admins.astro
+++ b/web/src/pages/admins.astro
@@ -1,0 +1,13 @@
+---
+import AdminPageLayout from '../layouts/AdminPageLayout.astro';
+import TableContainer from '../layouts/TableContainer.astro';
+import AdminTable from '../components/AdminTable';
+
+const title = 'Administrative Users';
+---
+
+<AdminPageLayout title={title}>
+  <TableContainer btnText="+ New Admin" btnHref="newUser" title={title}>
+    <AdminTable client:load />
+  </TableContainer>
+</AdminPageLayout>

--- a/web/src/pages/editAdmin.astro
+++ b/web/src/pages/editAdmin.astro
@@ -1,0 +1,13 @@
+---
+import AdminPageLayout from '../layouts/AdminPageLayout.astro';
+import PageContainer from '../layouts/PageContainer.astro';
+import AdminForm from '../components/AdminForm';
+
+const title = 'Edit Admin User';
+---
+
+<AdminPageLayout title={title}>
+  <PageContainer narrow title={title}>
+    <AdminForm client:load admin />
+  </PageContainer>
+</AdminPageLayout>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -3,9 +3,7 @@ import AdminPageLayout from '../layouts/AdminPageLayout.astro';
 import TableContainer from '../layouts/TableContainer.astro';
 import UserTable from '../components/UserTable';
 
-const description = `The users listed on this page are the team leads of Content Commons external partners. These
-    team leads help manage the external partner(s) who help provide content to be utilized by
-    Department of State PD personnel.`;
+const description = `The users listed on this page are the team leads of Content Commons external partners. These team leads help manage the external partner(s) who help provide content to be utilized by Department of State PD personnel.`;
 const title = 'External Partner Team Leads';
 ---
 

--- a/web/src/pages/newAdmin.astro
+++ b/web/src/pages/newAdmin.astro
@@ -1,0 +1,13 @@
+---
+import AdminPageLayout from '../layouts/AdminPageLayout.astro';
+import PageContainer from '../layouts/PageContainer.astro';
+import AdminForm from '../components/AdminForm';
+
+const title = 'New Admin';
+---
+
+<AdminPageLayout title={title}>
+  <PageContainer narrow title={title}>
+    <AdminForm client:load />
+  </PageContainer>
+</AdminPageLayout>

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -5,7 +5,7 @@ const API_ENDPOINT = import.meta.env.PUBLIC_SERVERLESS_URL;
 // Types and Interfaces
 // ////////////////////////////////////////////////////////////////////////////
 export type TActions = 'create' | 'confirm';
-export type TMethods = 'GET' | 'POST';
+export type TMethods = 'DELETE' | 'GET' | 'POST' | 'PUT';
 
 // ////////////////////////////////////////////////////////////////////////////
 // Helpers

--- a/web/src/utils/auth.ts
+++ b/web/src/utils/auth.ts
@@ -31,7 +31,7 @@ const makeAdminVerificationFn = ( roles: TUserRole[] ): TPermissionVerificationF
   let authenticated = false;
 
   try {
-    const response = await buildQuery( 'admin/get', { username: email }, 'POST' );
+    const response = await buildQuery( `admin?username=${email}`, null, 'GET' );
     const { data } = await response.json();
     const { role } = data;
 

--- a/web/src/utils/login.ts
+++ b/web/src/utils/login.ts
@@ -60,14 +60,16 @@ export const handleAdminLogin = async () => {
       const { email, exp } = payload;
 
       // Retrieve additional data from the application.
-      const response = await buildQuery( 'admin/get', { username: email }, 'POST' );
+      const response = await buildQuery( `admin?username=${email}`, null, 'POST' );
       const { data } = await response.json();
-      const { role, team } = data;
+      const { active, role, team } = data;
 
       // Add the required data from the id token to the current user store.
-      setCurrentUser( { email, team, role, exp } );
-      loginStatus.set( 'loggedIn' );
-      authenticated = true;
+      if ( active ) {
+        setCurrentUser( { email, team, role, exp } );
+        loginStatus.set( 'loggedIn' );
+        authenticated = true;
+      }
     }
   } catch ( err ) {
     console.log( err );

--- a/web/src/utils/routes.tsx
+++ b/web/src/utils/routes.tsx
@@ -1,4 +1,4 @@
-import type { TUserRole } from "../stores/current-user";
+import type { TUserRole } from '../stores/current-user';
 
 interface IRoute {
   href: string;
@@ -10,18 +10,21 @@ export const routes: IRoute[] = [
   {
     href: '',
     name: 'Home',
-    rolesAccessible: [ 'admin', 'super admin' ]
+    rolesAccessible: ['admin', 'super admin'],
   },
   {
     href: 'teams',
-    rolesAccessible: [ 'super admin' ],
+    rolesAccessible: ['super admin'],
+  },
+  {
+    href: 'admins',
+    rolesAccessible: ['super admin'],
   },
   {
     href: 'upload',
   },
-]
+];
 
 
-export const filterRoutes = ( userRole: TUserRole ) => {
-  return routes.filter( r => !r.rolesAccessible || r.rolesAccessible.includes( userRole ) );
-}
+export const filterRoutes = ( userRole: TUserRole ) => routes
+  .filter( r => !r.rolesAccessible || r.rolesAccessible.includes( userRole ) );


### PR DESCRIPTION
Adds a page where super admin users can manage other admin users. Specifically:

- Adds an admin update serverless function.
- Adds an admin deactivate serverless function.
- Switches the `admin/get` endpoint to a GET request on the `admin` endpoint using query parameters rather than a POST request body.
- Creates an `AdminForm` to add/edit admin users.
- Adds an `admin` page to show a table of all administrative users.