### PR TITLE
Permissions

### DIFF
--- a/serverless/config/resources/s3.yml
+++ b/serverless/config/resources/s3.yml
@@ -4,6 +4,13 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: commons-gateway-${opt:stage}-upload
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders: ${file(./config/${param:deployment}.json):cors.headers}
+            AllowedMethods:
+              - PUT
+            AllowedOrigins: ${file(./config/${param:deployment}.json):cors.origins}
+            Id: commons-gateway-${opt:stage}-upload-cors
 
   # Bucket where successfully scanned files end up.
   CleanBucket:

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -29,6 +29,15 @@ provider:
             - - 'arn:aws:rds-db:${aws:region}:${aws:accountId}:dbuser:'
               - !Select [6, !Split [':', !GetAtt RDSProxy.DBProxyArn]]
               - /*
+        - Effect: Allow
+          Action:
+            - s3:GetObject
+            - s3:PutObject
+            - s3:PutObjectTagging
+          Resource: !Join
+            - ''
+            - - !GetAtt UploadBucket.Arn
+              - /*
   vpc:
     securityGroupIds:
       - !Ref LambdaSecurityGroup


### PR DESCRIPTION
Addresses some issues with permissions on the automatically created upload bucket. Namely,

- Adds a CORS configuration to the bucket
- Adds a IAM policy to allow for uploading to the bucket

I also discovered that the `upload-metadata` function needed to be adjusted to accommodate the data restructuring we did last week. I added an intermediary step to retrieve the user's `user_id` from the `all_users` table based on their provided email. This value is what is passed to the INSERT statement in `createUploadRecord`.