### PR TITLE
fix(web): Moves banner from HTML header to header element in body

### DIFF
--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -18,9 +18,9 @@ const global = globalThis; // Needed by AWS Amplify.
 </script>
 
 <html lang="en">
-  <Banner />
   <Head title={title} />
   <body>
+    <Banner />
     <Header centered={centered} />
     <main id="root">
       <slot />


### PR DESCRIPTION
After merging the banner code I noticed that it was being injected into the HTML `<head>` section instead of before the `<Header />` element in the body, which causes console errors loading the page metadata (e.g., `charset`)