### PR TITLE
fix: Log out user on token expiration

### DIFF
--- a/serverless/utils/security/jwt/jwt.go
+++ b/serverless/utils/security/jwt/jwt.go
@@ -100,9 +100,15 @@ func RequestIsAuthorized(req events.APIGatewayProxyRequest, scopes []string) (in
 	}
 
 	err = VerifyJWT(token, scopes)
-	if err != nil {
-		return 403, err
-	} else {
+
+	// Everything looks good and client can continue
+	if err == nil {
 		return 200, nil
+		// Token is expired and client should re-login
+	} else if errors.Is(err, jwt.ErrTokenExpired) {
+		return 401, err
+		// Token is invalid and client must be rejected
+	} else {
+		return 403, err
 	}
 }

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -6,6 +6,9 @@
     "plugin:astro/recommended"
   ],
   "parser": "@typescript-eslint/parser",
+  "plugins": [
+      "@typescript-eslint"
+  ],
   "rules": {
     "react/jsx-filename-extension": [
       "error",

--- a/web/src/components/AdminTable.tsx
+++ b/web/src/components/AdminTable.tsx
@@ -101,7 +101,7 @@ const AdminTable: FC = () => {
   );
 
   return (
-    <div style={ { display: 'flex' } }>
+    <div style={ { display: 'flex', marginBottom: '0.75em' } }>
       { admins.length
         ? (
           <Table

--- a/web/src/components/ExternalPartnerTables/ExternalPartnerTables.tsx
+++ b/web/src/components/ExternalPartnerTables/ExternalPartnerTables.tsx
@@ -10,7 +10,7 @@ const ExternalPartnerTables: FC = () => {
 
   return (
     <div>
-      <select className={ style.select } value={ table } onChange={ e => setTable( e.target.value ) }>
+      <select className={ style.select } value={ table } onChange={ e => setTable( e.target.value ) } aria-label="User Type">
         <option value="partners">External Partners</option>
         <option value="leads">External Team Leads</option>
       </select>

--- a/web/src/components/InviteTable.tsx
+++ b/web/src/components/InviteTable.tsx
@@ -154,7 +154,7 @@ const UserTable: FC = () => {
   );
 
   return (
-    <div style={ { display: 'flex' } }>
+    <div style={ { display: 'flex', marginBottom: '0.75em' } }>
       { users.length
         ? (
           <Table

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -171,23 +171,29 @@ export const PaginationFooter = <T, >( { table }: { readonly table: ReactTable<T
         aria-label="Go to page"
       />
     </span>
-    <select
-      value={ table.getState().pagination.pageSize }
-      onChange={ e => {
-        table.setPageSize( Number( e.target.value ) );
-      } }
-      className={ style['page-show-select'] }
-      style={ { width: 'auto' } }
-      aria-label="Select number of results per page"
-    >
-      { [
-        10, 20, 30, 40, 50,
-      ].map( pageSize => (
-        <option key={ pageSize } value={ pageSize }>
-          { `Show ${pageSize}` }
-        </option>
-      ) ) }
-    </select>
+    <span className={ style['go-to-page-container'] }>
+      { 'Show' }
+      <select
+        value={ table.getState().pagination.pageSize }
+        onChange={ e => {
+          table.setPageSize( Number( e.target.value ) );
+        } }
+        className={ style['page-show-select'] }
+        style={ { width: 'auto', marginLeft: '0.375em', marginRight: '0.375em' } }
+        aria-label="Select number of results per page"
+      >
+        {
+          [ 10, 20, 30, 40, 50 ]
+            .filter( ( val, idx ) => val < table.getFilteredRowModel().rows.length || idx === 0 )
+            .map( pageSize => (
+              <option key={ pageSize } value={ pageSize }>
+                { pageSize }
+              </option>
+            ) )
+        }
+      </select>
+      { 'per page' }
+    </span>
   </div>
 );
 

--- a/web/src/components/TeamTable.tsx
+++ b/web/src/components/TeamTable.tsx
@@ -72,7 +72,7 @@ const TeamTable: FC = () => {
   );
 
   return (
-    <div style={ { display: 'flex', flexDirection: 'column' } }>
+    <div style={ { display: 'flex', flexDirection: 'column', marginBottom: '0.75em' } }>
       <TeamModal
         anchor={ (
           <span

--- a/web/src/components/UploaderTable.tsx
+++ b/web/src/components/UploaderTable.tsx
@@ -116,7 +116,7 @@ const UploaderTable: FC = () => {
   );
 
   return (
-    <div style={ { display: 'flex' } }>
+    <div style={ { display: 'flex', marginBottom: '0.75em' } }>
       { users.length
         ? (
           <Table

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -2,6 +2,7 @@
 // Local Imports
 // ////////////////////////////////////////////////////////////////////////////
 import { accessToken } from '../stores/current-user';
+import { logout } from './login';
 
 // ////////////////////////////////////////////////////////////////////////////
 // Types and Interfaces
@@ -58,5 +59,12 @@ export const buildQuery = async ( endpoint: string, body: Nullable<Record<string
     };
   }
 
-  return fetch( constructUrl( endpoint ), opts );
+  // 401 means the token is expired, so log out user for UX reasons
+  const response = await fetch( constructUrl( endpoint ), opts );
+
+  if ( response.status === 401 ) {
+    logout();
+  }
+
+  return response;
 };


### PR DESCRIPTION
The primary result of this PR is to differentiate an expired JWT (401) from an invalid one (403) and redirect the user as appropriate.  This should prevent the apparent UI freezing that can occur when a user returns to a page after an extended period, as currently session validity is checked only on page load.

Also corrects one accessibility issue from ANDI and cleans up table footers and spacing.