### PR TITLE
feat(web/upload): Adds loading indicator to upload page

### DIFF
--- a/web/src/pages/upload.astro
+++ b/web/src/pages/upload.astro
@@ -39,11 +39,12 @@ const title = 'Submit Files';
     <p class="section-header"><strong>Description <span>*</span></strong></p>
     <p>Include a point of contact email in case questions arise.</p>
     <textarea id="description-text" aria-label="Enter uploaded media metadata" />
+    <span id="loader" class="loader" style="display: none;"></span>
     <Button id="upload-files-btn" type="submit">Submit</Button>
   </PageContainer>
 </LoggedInPageLayout>
 
-<style>
+<style lang="scss">
   p,
   strong {
     color: var(--blue);
@@ -77,4 +78,32 @@ const title = 'Submit Files';
     list-style: none;
     padding: 0;
   }
+  .loader {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: block;
+    margin:15px auto;
+    position: relative;
+    margin-left: 3em;
+    color: var(--blue);
+    box-sizing: border-box;
+    animation: animloader 1s linear infinite alternate;
+  }
+
+  @keyframes animloader {
+    0% {
+      box-shadow: -38px -6px, -14px 6px,  14px -6px;
+    }
+    33% {
+      box-shadow: -38px 6px, -14px -6px,  14px 6px;
+    }
+    66% {
+      box-shadow: -38px -6px, -14px 6px, 14px -6px;
+    }
+    100% {
+      box-shadow: -38px 6px, -14px -6px, 14px 6px;
+    }
+  }
+
 </style>

--- a/web/src/utils/alert.ts
+++ b/web/src/utils/alert.ts
@@ -61,6 +61,17 @@ export const showInfo = ( title: string, text: string ) => Swal.fire( {
   buttonsStyling: false,
 } );
 
+export const showWarning = ( text: string, heading?: string ) => Swal.fire( {
+  icon: 'warning',
+  title: heading || 'Warning',
+  text,
+  customClass: {
+    confirmButton: REJECT_BTN_STYLE_CLASSES,
+    popup: alertStyles.text,
+  },
+  buttonsStyling: false,
+} );
+
 export const showConfirm = ( text: string ) => Swal.fire( {
   icon: 'warning',
   title: 'Please confirm your selection',

--- a/web/src/utils/files.ts
+++ b/web/src/utils/files.ts
@@ -7,7 +7,7 @@ import prettyBytes from 'pretty-bytes';
 // Local Imports
 // ////////////////////////////////////////////////////////////////////////////
 import { submitFiles } from './upload';
-import { showError, showSuccess } from './alert';
+import { showError, showSuccess, showWarning } from './alert';
 
 import currentUser from '../stores/current-user';
 
@@ -70,10 +70,10 @@ const validateSubmission = ( descriptionElem: HTMLInputElement ) => {
     showError( 'Internal error' );
     error = true;
   } else if ( !file ) {
-    showError( 'No file has been selected for upload' );
+    showWarning( 'No file has been selected for upload', 'Invalid Submission' );
     error = true;
   } else if ( !description ) {
-    showError( 'No file description provided' );
+    showWarning( 'No file description provided', 'Invalid Submission' );
     error = true;
   } else if ( !email ) {
     showError( 'No current user email' );
@@ -85,6 +85,17 @@ const validateSubmission = ( descriptionElem: HTMLInputElement ) => {
 
   return { description, file, error, email, team };
 };
+
+const switchSubmitDisplay = () => {
+  const btn = document.getElementById( 'upload-files-btn' ) as HTMLInputElement;
+  const btnHidden = ( btn.style.display === 'none' );
+  btn.style.display = ( btnHidden ? 'block' : 'none' );
+
+  const loader = document.getElementById( 'loader' ) as HTMLInputElement;
+  console.log( loader );
+  const loaderHidden = ( loader.style.display === 'none' );
+  loader.style.display = ( loaderHidden ? 'block' : 'none' );
+}
 
 // ////////////////////////////////////////////////////////////////////////////
 // Exports
@@ -121,6 +132,8 @@ export const chooseHandler = ( e: Event ) => {
 };
 
 export const submitHandler = async () => {
+  switchSubmitDisplay();
+
   // Prepare and validate
   const descriptionElem = document.getElementById( 'description-text' ) as HTMLInputElement;
   const fileElem = document.getElementById( 'file-list' ) as HTMLInputElement;
@@ -128,6 +141,7 @@ export const submitHandler = async () => {
   const { file, description, email, team, error } = validateSubmission( descriptionElem );
 
   if ( error ) {
+    switchSubmitDisplay();
     return;
   }
 
@@ -144,4 +158,6 @@ export const submitHandler = async () => {
   descriptionElem.value = '';
   fileElem.innerHTML = '';
   fileToUpload = null;
+
+  switchSubmitDisplay();
 };

--- a/web/src/utils/files.ts
+++ b/web/src/utils/files.ts
@@ -92,7 +92,6 @@ const switchSubmitDisplay = () => {
   btn.style.display = ( btnHidden ? 'block' : 'none' );
 
   const loader = document.getElementById( 'loader' ) as HTMLInputElement;
-  console.log( loader );
   const loaderHidden = ( loader.style.display === 'none' );
   loader.style.display = ( loaderHidden ? 'block' : 'none' );
 }


### PR DESCRIPTION
Adds pure CSS loading indicator to uploads page and cleans up UX to differentiate between user-caused upload errors (fixable) and internal upload errors (not fixable).

The included loading indicator is pretty basic but it gets the point across and has no dependencies.  There are [hundreds of alternatives](https://cssloaders.github.io/) from the same source if we want to switch up the style.