### PR TITLE
Client side password hashing

### DIFF
--- a/.config/dictionaries/dependencies.txt
+++ b/.config/dictionaries/dependencies.txt
@@ -10,3 +10,4 @@ sweetalert
 tanstack
 thanhpk
 tsconfigs
+zxcvbn

--- a/.config/dictionaries/html.txt
+++ b/.config/dictionaries/html.txt
@@ -1,0 +1,9 @@
+# Common HTML events set off the spell checker
+dragenter
+dragover
+
+# CSS/SCSS
+keyframes
+
+# White Space
+nbsp

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -9,20 +9,28 @@
       "path": "../.config/dictionaries/dependencies.txt"
     },
     {
+      "name": "HTML",
+      "path": "../.config/dictionaries/html.txt"
+    },
+    {
       "name": "Postgres",
       "path": "../.config/dictionaries/postgres.txt"
     }
   ],
   "dictionaries": [
     "CloudFormation",
+    "HTML",
     "Dependencies",
     "Postgres"
   ],
   "words": [
+    "animloader",
     "Aprimo",
+    "curr",
     "funcs",
     "querystrings",
     "signout",
+    "sitekey",
     "somepage"
   ]
 }

--- a/serverless/funcs/creds-2fa/main.go
+++ b/serverless/funcs/creds-2fa/main.go
@@ -121,9 +121,6 @@ func generateMfaHandler(ctx context.Context, event events.APIGatewayProxyRequest
 		return msgs.SendServerError(err)
 	}
 
-	// DBG
-	fmt.Printf("New code for username %s: %s\n", username, code)
-
 	// Email the user their code.
 	err = initiateEmailQueue(username, code)
 

--- a/serverless/funcs/creds-provision/schema.json
+++ b/serverless/funcs/creds-provision/schema.json
@@ -49,6 +49,6 @@
       "maxLength": 127
     }
   },
-  "required": ["expiration"],
+  "required": ["expiration", "invitee", "inviter"],
   "additionalProperties": false
 }

--- a/serverless/funcs/creds-salt/main.go
+++ b/serverless/funcs/creds-salt/main.go
@@ -55,7 +55,12 @@ func GetSaltHandler(ctx context.Context, event events.APIGatewayProxyRequest) (m
 		return msgs.SendCustomError(errors.New("account locked"), 429)
 	}
 
-	body, err := msgs.MarshalBody(credentials.Salt)
+	salts := map[string]any{
+		"salt":      credentials.Salt,
+		"prevSalts": credentials.PrevSalts,
+	}
+
+	body, err := msgs.MarshalBody(salts)
 
 	if err != nil {
 		return msgs.SendServerError(err)

--- a/serverless/funcs/email-2fa/main.go
+++ b/serverless/funcs/email-2fa/main.go
@@ -34,7 +34,7 @@ func formatEmailBody(user data.User, code string) string {
 		`<p>%s %s,</p>
 		<p>Please use this verification code to complete your sign in:</p>
 		<p>%s</p>
-		<p>If you did not make this request, please disregard this email. </p>`,
+		<p>Please note that this verification code will expire in 20 minutes. If you did not make this request, please disregard this email. </p>`,
 		user.NameFirst, user.NameLast, code,
 	)
 }

--- a/serverless/funcs/password-change/main.go
+++ b/serverless/funcs/password-change/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/IIP-Design/commons-gateway/utils/security/hashing"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/nbutton23/zxcvbn-go"
 	"github.com/rs/xid"
 )
 
@@ -106,12 +105,6 @@ func checkPasswordReused(email string, hashedPriorSalts []string) (bool, error) 
 	}
 
 	return reused, err
-}
-
-func checkNewPasswordStrength(email string, role string, newPassword string) bool {
-	result := zxcvbn.PasswordStrength(newPassword, []string{email, role})
-	success := (result.Score >= 3)
-	return success
 }
 
 func updatePassword(email string, salt string, newPassword string, newSalt string) error {

--- a/serverless/funcs/password-change/main.go
+++ b/serverless/funcs/password-change/main.go
@@ -138,24 +138,28 @@ func updatePassword(email string, salt string, newPassword string, newSalt strin
 
 func PasswordChangeHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
 	parsed, err := extractBody(event.Body)
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}
 
 	credentials, err := verifyUser(parsed)
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}
 
 	passwordIsSecure := checkNewPasswordStrength(parsed.Email, credentials.Role, parsed.NewPassword)
+
 	if !passwordIsSecure {
 		return msgs.SendCustomError(errors.New("password is not strong enough"), 422)
 	}
 
-	passwordIsResused, err := checkPasswordReused(parsed.Email, parsed.NewPassword)
+	passwordIsReused, err := checkPasswordReused(parsed.Email, parsed.NewPassword)
+
 	if err != nil {
 		return msgs.SendServerError(err)
-	} else if passwordIsResused {
+	} else if passwordIsReused {
 		return msgs.SendCustomError(errors.New("password was reused"), 409)
 	}
 

--- a/serverless/funcs/password-change/main.go
+++ b/serverless/funcs/password-change/main.go
@@ -18,9 +18,10 @@ import (
 )
 
 type PasswordReset struct {
-	CurrentPasswordHash string `json:"currentPasswordHash"`
-	NewPassword         string `json:"newPassword"`
-	Email               string `json:"email"`
+	CurrentPasswordHash string   `json:"currentPasswordHash"`
+	NewPassword         string   `json:"newPassword"`
+	HashedPriorSalts    []string `json:"hashesWithPriorSalts"`
+	Email               string   `json:"email"`
 }
 
 func extractBody(body string) (PasswordReset, error) {
@@ -36,15 +37,19 @@ func extractBody(body string) (PasswordReset, error) {
 	return parsed, err
 }
 
+// verifyUser confirms that the user requesting a password change exists
+// and has provided the correct password.
 func verifyUser(parsed PasswordReset) (creds.CredentialsData, error) {
 	var credentials creds.CredentialsData
 
 	_, exists, err := data.CheckForExistingUser(parsed.Email, "guests")
+
 	if err != nil || !exists {
 		return credentials, errors.New("user does not exist")
 	}
 
 	credentials, err = creds.RetrieveCredentials(parsed.Email)
+
 	if err != nil {
 		return credentials, errors.New("failed to load credentials")
 	}
@@ -56,14 +61,14 @@ func verifyUser(parsed PasswordReset) (creds.CredentialsData, error) {
 	return credentials, nil
 }
 
-func checkPasswordReused(email string, newPassword string) (bool, error) {
+func checkPasswordReused(email string, hashedPriorSalts []string) (bool, error) {
 	var err error
 	reused := false
 
 	pool := data.ConnectToDB()
 	defer pool.Close()
 
-	query := "SELECT creation_date, salt, pass_hash FROM password_history WHERE user_id = $1 ORDER BY creation_date DESC LIMIT 24;"
+	query := "SELECT creation_date, pass_hash FROM password_history WHERE user_id = $1 ORDER BY creation_date DESC LIMIT 24;"
 	rows, err := pool.Query(query, email)
 
 	if err != nil {
@@ -71,21 +76,27 @@ func checkPasswordReused(email string, newPassword string) (bool, error) {
 		return reused, err
 	}
 
+	// Convert list of hashes generated using previous salts into a map for easier searching.
+	hashMap := make(map[string]string, len(hashedPriorSalts))
+	for i := range hashedPriorSalts {
+		hashMap[hashedPriorSalts[i]] = hashedPriorSalts[i]
+	}
+
 	defer rows.Close()
 
 	for rows.Next() {
 		var date time.Time
-		var salt string
 		var passHash string
 
-		if err := rows.Scan(&date, &salt, &passHash); err != nil {
+		if err := rows.Scan(&date, &passHash); err != nil {
 			logs.LogError(err, "Pass Reuse Scan Error")
 			return reused, err
 		}
 
-		newPassHash := hashing.GenerateHash(newPassword, salt)
-		if newPassHash == passHash {
-			reused = (newPassHash == passHash)
+		_, found := hashMap[passHash]
+
+		if found {
+			reused = true
 			break
 		}
 	}
@@ -149,13 +160,7 @@ func PasswordChangeHandler(ctx context.Context, event events.APIGatewayProxyRequ
 		return msgs.SendServerError(err)
 	}
 
-	passwordIsSecure := checkNewPasswordStrength(parsed.Email, credentials.Role, parsed.NewPassword)
-
-	if !passwordIsSecure {
-		return msgs.SendCustomError(errors.New("password is not strong enough"), 422)
-	}
-
-	passwordIsReused, err := checkPasswordReused(parsed.Email, parsed.NewPassword)
+	passwordIsReused, err := checkPasswordReused(parsed.Email, parsed.HashedPriorSalts)
 
 	if err != nil {
 		return msgs.SendServerError(err)
@@ -165,6 +170,7 @@ func PasswordChangeHandler(ctx context.Context, event events.APIGatewayProxyRequ
 
 	_, newSalt := hashing.GenerateCredentials()
 	err = updatePassword(parsed.Email, credentials.Salt, parsed.NewPassword, newSalt)
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}

--- a/serverless/funcs/password-change/schema.json
+++ b/serverless/funcs/password-change/schema.json
@@ -9,10 +9,15 @@
       "type": "string",
       "minLength": 1
     },
-    "newPassword": {
-      "description": "The password to which a user wants to update",
+    "newPasswordHash": {
+      "description": "A hash of the password to which a user wants to update",
       "type": "string",
       "minLength": 12
+    },
+    "newSalt": {
+      "description": "The salt value used when generating the new user password hash.",
+      "type": "string",
+      "minLength": 10
     },
     "hashesWithPriorSalts": {
       "description": "The newly created password hashed using previous salt values",
@@ -29,6 +34,12 @@
       "maxLength": 127
     }
   },
-  "required": ["currentPasswordHash", "newPassword", "hashesWithPriorSalts", "email"],
+  "required": [
+    "currentPasswordHash",
+    "newPasswordHash",
+    "newSalt",
+    "hashesWithPriorSalts",
+    "email"
+  ],
   "additionalProperties": false
 }

--- a/serverless/funcs/password-change/schema.json
+++ b/serverless/funcs/password-change/schema.json
@@ -14,6 +14,13 @@
       "type": "string",
       "minLength": 12
     },
+    "hashesWithPriorSalts": {
+      "description": "The newly created password hashed using previous salt values",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "email": {
       "description": "The user's email address",
       "type": "string",
@@ -22,6 +29,6 @@
       "maxLength": 127
     }
   },
-  "required": ["currentPasswordHash", "newPassword", "email"],
+  "required": ["currentPasswordHash", "newPassword", "hashesWithPriorSalts", "email"],
   "additionalProperties": false
 }

--- a/serverless/go.mod
+++ b/serverless/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.24.5
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/lib/pq v1.10.9
-	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354
 	github.com/rs/xid v1.5.0
 	golang.org/x/crypto v0.13.0
 )

--- a/serverless/go.sum
+++ b/serverless/go.sum
@@ -56,14 +56,11 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6FxaNu/BnU2OAaLF86eTVhP2hjTB6iMvItA=
-github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=

--- a/serverless/utils/email/provision/provision.go
+++ b/serverless/utils/email/provision/provision.go
@@ -23,7 +23,7 @@ func formatEmailBody(invitee data.User, tmpPassword string, url string) string {
 
 	<p>Your content upload account has been successfully created.  Please access the link below to finish provisioning your account.</p>
 	<a href="%s">%s</a>
-	<p>Please use this email address as your username.  Your temporary password is: %s.</p>
+	<p>Please use this email address as your username.  Your temporary password is: %s</p>
 	<p>This email was generated automatically. Please do not reply to this email.</p>`,
 		invitee.NameFirst, invitee.NameLast,
 		url, url,

--- a/web/src/components/File.astro
+++ b/web/src/components/File.astro
@@ -1,4 +1,6 @@
 ---
+import styles from '../styles/button.module.scss';
+
 interface Props {
   class?: string;
   id?: string;
@@ -10,17 +12,13 @@ const { class: classes, id, promptText, buttonText } = Astro.props;
 ---
 
 <div style="display: inline;">
-    <label for={id}>{promptText}</label>
-    <input
-        class:list={[classes]}
-        id={id || ''}
-        type="file"
-        style="display: none;"
-    />
-    <input
-        type="button"
-        value={buttonText || 'Browse...'}
-        onclick=`document.getElementById("${id}").click();`
-        style="display: inline;"
-    />
+  <label for={id}>{promptText}</label>
+  <input class:list={[classes]} id={id || ''} type="file" style="display: none;" />
+  <input
+    type="button"
+    class={styles.btn}
+    value={buttonText || 'Browse'}
+    onclick=`document.getElementById("${id}").click();`
+    style="display: inline; cursor: pointer;"
+  />
 </div>

--- a/web/src/components/UploaderTable.tsx
+++ b/web/src/components/UploaderTable.tsx
@@ -87,7 +87,7 @@ const UploaderTable: FC = () => {
       {
         ...defaultColumnDef( 'active', 'Status' ),
         cell: info => {
-          const isPending = info.row.original['pending'] as boolean;
+          const isPending = info.row.original.pending as boolean;
           const isActive = info.getValue() as boolean;
 
 

--- a/web/src/pages/partner-login.astro
+++ b/web/src/pages/partner-login.astro
@@ -156,11 +156,11 @@ const { PUBLIC_TURNSTILE_SITE_KEY } = import.meta.env;
         type="checkbox"
         style="display: inline; white-space: pre; margin: 0 0.5rem 0 0"
       />
-      I acknowledge the&nbsp;<button
-        id="monitoring-consent"
-        class={`consent ${btnStyles['link-btn']}`}
-        type="button">monitoring consent notice</button
-      >&nbsp;while using this system
+      <span>I acknowledge the&nbsp;</span>
+      <button id="monitoring-consent" class={`consent ${btnStyles['link-btn']}`} type="button">
+        monitoring consent notice
+      </button>
+      <span>&nbsp;while using this system</span>
     </label>
     <Button id="mfa-btn" class={btnStyles['disabled-btn']} type="button" disabled>
       Request 2FA Code

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -17,6 +17,7 @@ const desc = 'Because this is your first login with this invite, you must update
   import currentUser, { loginStatus } from '../stores/current-user';
   import { derivePasswordHash } from '../utils/hashing';
   import { buildQuery } from '../utils/api';
+  import { randomString } from '../utils/string';
 
   interface ISubData {
     email: string;
@@ -136,9 +137,14 @@ const desc = 'Because this is your first login with this invite, you must update
         prevSalts.map(async (prev: string) => await derivePasswordHash(newPassword, prev))
       );
 
+      // Generate random salt and use it to hash the user's new password.
+      const newSalt = randomString(10);
+      const newPasswordHash = await derivePasswordHash(newPassword, newSalt);
+
       const body = {
         currentPasswordHash,
-        newPassword,
+        newPasswordHash,
+        newSalt,
         hashesWithPriorSalts,
         email,
       };

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -159,8 +159,6 @@ const desc = 'Because this is your first login with this invite, you must update
             window.location.replace('/partner-login');
           }
         });
-      } else if (status === 422) {
-        showWarning('Password is not strong enough');
       } else if (status === 409) {
         showWarning('You cannot reuse any of your last 24 passwords');
       } else {

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -6,17 +6,17 @@ import PageContainer from '../layouts/PageContainer.astro';
 import '../styles/form.scss';
 
 const title = 'Update Password';
-const desc = "Because this is your first login with this invite, you must update your password"
+const desc = 'Because this is your first login with this invite, you must update your password';
 ---
 
 <script>
-  import zxcvbn from "zxcvbn";
+  import zxcvbn from 'zxcvbn';
 
-  import { showError, showSuccess, showWarning } from "../utils/alert";
-  import { getUserPasswordSalt } from "../utils/login";
-  import currentUser, { loginStatus } from "../stores/current-user";
-  import { derivePasswordHash } from "../utils/hashing";
-  import { buildQuery } from "../utils/api";
+  import { showError, showSuccess, showWarning } from '../utils/alert';
+  import { getUserPasswordSalt } from '../utils/login';
+  import currentUser, { loginStatus } from '../stores/current-user';
+  import { derivePasswordHash } from '../utils/hashing';
+  import { buildQuery } from '../utils/api';
 
   interface ISubData {
     email: string;
@@ -25,6 +25,29 @@ const desc = "Because this is your first login with this invite, you must update
     newPassword: string;
   }
 
+  /**
+   * Switch the input fields from passwords to text when in focus.
+   * @param el The input element in question.
+   */
+  const toggleInputType = (el: FocusEvent) => {
+    const { type, target } = el;
+    const { id } = target as HTMLInputElement;
+
+    const inputType = type === 'focus' ? 'text' : 'password';
+
+    if (id) {
+      const input = document.getElementById(id) as HTMLInputElement;
+      input.type = inputType;
+    }
+  };
+
+  // Toggle the visibility of the password input fields when they are selected/deselected.
+  const inputs = document.querySelectorAll('input');
+
+  inputs.forEach((input) => input?.addEventListener('focus', toggleInputType));
+  inputs.forEach((input) => input?.addEventListener('blur', toggleInputType));
+
+  // Handle the submission of new passwords
   const collectSubmissionData = (): ISubData => {
     const user = currentUser.get();
     const email = user.email || '';
@@ -39,59 +62,63 @@ const desc = "Because this is your first login with this invite, you must update
     return { email, role, currPassword, newPassword };
   };
 
-  const checkPassword = (  { email, role, currPassword, newPassword }: ISubData ) => {
-    if( currPassword === newPassword ) {
+  const checkPassword = ({ email, role, currPassword, newPassword }: ISubData) => {
+    if (currPassword === newPassword) {
       showWarning('Your new password must not be the same as your current password');
       return false;
-    } else if( newPassword.length < 12 ) {
+    } else if (newPassword.length < 12) {
       showWarning('Your new password must be at least 12 characters long');
       return false;
-    } else if( !( newPassword.match( /[A-Z]/ ) && newPassword.match( /[a-z]/ ) && newPassword.match( /[0-9]/ ) ) ) {
-      showWarning('Your new password must contain at least one of each: lowercase letter, uppercase letter, number');
+    } else if (
+      !(newPassword.match(/[A-Z]/) && newPassword.match(/[a-z]/) && newPassword.match(/[0-9]/))
+    ) {
+      showWarning(
+        'Your new password must contain at least one of each: lowercase letter, uppercase letter, number'
+      );
       return false;
     }
 
     const passResult = zxcvbn(newPassword, [email, role].filter(Boolean));
-    if( passResult.score < 3 ) {
+    if (passResult.score < 3) {
       const { warning, suggestions } = passResult.feedback;
-      const warnText = `${warning}${warning ? "." : ""}`;
-      const suggestText = suggestions.map( ( s, idx ) => `(${idx+1}) ${s}` ).join(' ');
-      const text = `${warnText}${suggestText ? " Suggestions: " : ""}${suggestText}`
-      showWarning(text, "Password too weak");
+      const warnText = `${warning}${warning ? '.' : ''}`;
+      const suggestText = suggestions.map((s, idx) => `(${idx + 1}) ${s}`).join(' ');
+      const text = `${warnText}${suggestText ? ' Suggestions: ' : ''}${suggestText}`;
+      showWarning(text, 'Password too weak');
       return false;
     }
 
     return true;
-  }
+  };
 
-  const verifySubmissionData = ( subData: ISubData ) => {
+  const verifySubmissionData = (subData: ISubData) => {
     const { currPassword, newPassword } = subData;
 
-    if( !currPassword ) {
+    if (!currPassword) {
       showWarning('Please input your current password');
       return false;
-    } else if( !newPassword ) {
+    } else if (!newPassword) {
       showWarning('Please input a new password');
       return false;
     }
 
-    return checkPassword( subData );
-  }
+    return checkPassword(subData);
+  };
 
   const submit = async () => {
     const subData = collectSubmissionData();
-    const verified = verifySubmissionData( subData );
-    if( !verified ) {
+    const verified = verifySubmissionData(subData);
+    if (!verified) {
       return;
     }
 
     const { email, currPassword, newPassword } = subData;
 
-    const isFirstLogin = ( loginStatus.get() === 'firstLogin' );
+    const isFirstLogin = loginStatus.get() === 'firstLogin';
 
     try {
-      const [salt] = await getUserPasswordSalt( email );
-      const currentPasswordHash = await derivePasswordHash( currPassword, salt );
+      const [salt] = await getUserPasswordSalt(email);
+      const currentPasswordHash = await derivePasswordHash(currPassword, salt);
 
       const body = {
         currentPasswordHash,
@@ -99,58 +126,48 @@ const desc = "Because this is your first login with this invite, you must update
         email,
       };
 
-      const { ok, status } = await buildQuery( "guest/password", body, 'POST' );
-      if( ok ) {
-        loginStatus.set( 'loggedIn' );
-        showSuccess('Password successfully updated')
-          .then( () => {
-            if( isFirstLogin ) {
-              window.location.replace( "/partner-login" );
-            }
-          } );
-      } else if( status === 422 ) {
+      const { ok, status } = await buildQuery('guest/password', body, 'POST');
+      if (ok) {
+        loginStatus.set('loggedIn');
+        showSuccess('Password successfully updated').then(() => {
+          if (isFirstLogin) {
+            window.location.replace('/partner-login');
+          }
+        });
+      } else if (status === 422) {
         showWarning('Password is not strong enough');
-      } else if( status === 409 ) {
+      } else if (status === 409) {
         showWarning('You cannot reuse any of your last 24 passwords');
       } else {
         showError('Unable to update password');
       }
-    } catch( err ) {
-      console.error( err );
+    } catch (err) {
+      console.error(err);
     }
-
   };
 
-  document.getElementById('submit-btn')?.addEventListener( 'click', submit );
+  document.getElementById('submit-btn')?.addEventListener('click', submit);
 
-  const descElem = document.getElementById( 'desc-elem' ) as HTMLElement;
+  const descElem = document.getElementById('desc-elem') as HTMLElement;
   const isFirstLogin = loginStatus.get() === 'firstLogin';
-  if( !isFirstLogin ) {
+  if (!isFirstLogin) {
     descElem.style.display = 'none';
   }
 </script>
 
 <PartnerPageLayout title={title}>
   <PageContainer narrow title={title}>
-      <p id="desc-elem" class="description">{desc}</p>
-      <div class="field-group" style="margin-top: 1em;">
-        <label>
-          <span>Current Password</span>
-          <input
-            id="current-password-input"
-            type="text"
-            required
-          />
-        </label>
-        <label>
-          <span>New Password</span>
-          <input
-            id="new-password-input"
-            type="text"
-            required
-          />
-        </label>
-      </div>
-      <Button id="submit-btn" type="submit">Submit</Button>
+    <p id="desc-elem" class="description">{desc}</p>
+    <div class="field-group" style="margin-top: 1em;">
+      <label>
+        <span>Current Password</span>
+        <input id="current-password-input" type="password" required />
+      </label>
+      <label>
+        <span>New Password</span>
+        <input id="new-password-input" type="password" required />
+      </label>
+    </div>
+    <Button id="submit-btn" type="submit">Submit</Button>
   </PageContainer>
 </PartnerPageLayout>

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -79,6 +79,7 @@ const desc = 'Because this is your first login with this invite, you must update
     }
 
     const passResult = zxcvbn(newPassword, [email, role].filter(Boolean));
+
     if (passResult.score < 3) {
       const { warning, suggestions } = passResult.feedback;
       const warnText = `${warning}${warning ? '.' : ''}`;
@@ -108,6 +109,7 @@ const desc = 'Because this is your first login with this invite, you must update
   const submit = async () => {
     const subData = collectSubmissionData();
     const verified = verifySubmissionData(subData);
+
     if (!verified) {
       return;
     }
@@ -117,16 +119,24 @@ const desc = 'Because this is your first login with this invite, you must update
     const isFirstLogin = loginStatus.get() === 'firstLogin';
 
     try {
-      const [salt] = await getUserPasswordSalt(email);
+      const [{ salt, prevSalts }] = await getUserPasswordSalt(email);
       const currentPasswordHash = await derivePasswordHash(currPassword, salt);
+
+      // Derive the hash of the new password with previously used salts.
+      // Allows us to ensure that the user is not reusing a previous password.
+      const hashesWithPriorSalts = await Promise.all(
+        prevSalts.map(async (prev: string) => await derivePasswordHash(newPassword, prev))
+      );
 
       const body = {
         currentPasswordHash,
         newPassword,
+        hashesWithPriorSalts,
         email,
       };
 
       const { ok, status } = await buildQuery('guest/password', body, 'POST');
+
       if (ok) {
         loginStatus.set('loggedIn');
         showSuccess('Password successfully updated').then(() => {

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -48,13 +48,21 @@ const desc = 'Because this is your first login with this invite, you must update
   inputs.forEach((input) => input?.addEventListener('blur', toggleInputType));
 
   // Handle the submission of new passwords
+  const currPassElem = document.getElementById('current-password-input') as HTMLInputElement;
+  const newPassElem = document.getElementById('new-password-input') as HTMLInputElement;
+
+  /**
+   * Reset the current and new password fields to be empty.
+   */
+  const clearInputs = () => {
+    currPassElem.value = '';
+    newPassElem.value = '';
+  };
+
   const collectSubmissionData = (): ISubData => {
     const user = currentUser.get();
     const email = user.email || '';
     const role = user.role || '';
-
-    const currPassElem = document.getElementById('current-password-input') as HTMLInputElement;
-    const newPassElem = document.getElementById('new-password-input') as HTMLInputElement;
 
     const currPassword = currPassElem.value;
     const newPassword = newPassElem.value;
@@ -140,6 +148,7 @@ const desc = 'Because this is your first login with this invite, you must update
       if (ok) {
         loginStatus.set('loggedIn');
         showSuccess('Password successfully updated').then(() => {
+          clearInputs();
           if (isFirstLogin) {
             window.location.replace('/partner-login');
           }

--- a/web/src/pages/upload.astro
+++ b/web/src/pages/upload.astro
@@ -37,8 +37,8 @@ const title = 'Submit Files';
     <File id="add-files-button" promptText="or search your computer: " />
 
     <p class="section-header"><strong>Description <span>*</span></strong></p>
-    <p>Include a point of contact email in case questions arise.</p>
-    <textarea id="description-text" aria-label="Enter uploaded media metadata" />
+    <p class="desc-label">Include a point of contact email in case questions arise.</p>
+    <textarea id="description-text" aria-label="Enter uploaded media metadata"></textarea>
     <span id="loader" class="loader" style="display: none;"></span>
     <Button id="upload-files-btn" type="submit">Submit</Button>
   </PageContainer>
@@ -71,6 +71,9 @@ const title = 'Submit Files';
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
+  .desc-label {
+    margin: 0.5rem 0;
+  }
   .section-header {
     margin-top: 2rem;
   }
@@ -83,7 +86,7 @@ const title = 'Submit Files';
     height: 12px;
     border-radius: 50%;
     display: block;
-    margin:15px auto;
+    margin: 15px auto;
     position: relative;
     margin-left: 3em;
     color: var(--blue);
@@ -93,10 +96,10 @@ const title = 'Submit Files';
 
   @keyframes animloader {
     0% {
-      box-shadow: -38px -6px, -14px 6px,  14px -6px;
+      box-shadow: -38px -6px, -14px 6px, 14px -6px;
     }
     33% {
-      box-shadow: -38px 6px, -14px -6px,  14px 6px;
+      box-shadow: -38px 6px, -14px -6px, 14px 6px;
     }
     66% {
       box-shadow: -38px -6px, -14px 6px, 14px -6px;
@@ -105,5 +108,4 @@ const title = 'Submit Files';
       box-shadow: -38px 6px, -14px -6px, 14px 6px;
     }
   }
-
 </style>

--- a/web/src/styles/button.module.scss
+++ b/web/src/styles/button.module.scss
@@ -11,6 +11,11 @@
   border: none;
   background-color: var(--blue);
   color: #ffffff;
+
+  &:hover {
+    box-shadow: 2px 1px 3px 2px var(--greyLight);
+    transform: translate(-1px)
+  }
 }
 
 .btn-light {

--- a/web/src/utils/login.ts
+++ b/web/src/utils/login.ts
@@ -143,7 +143,7 @@ export const handlePartnerLogin = async ( username: string, password: string, mf
   let authenticated = false;
 
   try {
-    const [salt, saltError] = await getUserPasswordSalt( username );
+    const [{ salt }, saltError] = await getUserPasswordSalt( username );
 
     if ( !salt ) {
       return [authenticated, saltError];

--- a/web/src/utils/string.ts
+++ b/web/src/utils/string.ts
@@ -1,3 +1,9 @@
+/**
+ * Manipulates the given string value so that it begins with
+ * a capital letter followed by all lower case letters.
+ * @param str Any string value.
+ * @returns A capitalized version of the provided string.
+ */
 export const capitalize = ( str: string ): string => {
   if ( !str || !str.length ) {
     return '';
@@ -8,13 +14,17 @@ export const capitalize = ( str: string ): string => {
   return lower.substring( 0, 1 ).toUpperCase() + lower.substring( 1, lower.length );
 };
 
+/**
+ * Manipulate the given string so that it follows title casing,
+ * i.e. the first letter of each word is capitalized.
+ * @param str Any string value.
+ * @returns A title-case version of the provided string.
+ */
 export const titleCase = ( str: string ) => {
-  const parts
-      = str
-        ?.replace( /([A-Z])+/g, capitalize )
-        // eslint-disable-next-line no-useless-escape
-        ?.split( /(?=[A-Z])|[\.\-\s_]/ )
-        .map( x => x.toLowerCase() ) ?? [];
+  const parts = str
+    ?.replace( /([A-Z])+/g, capitalize )
+    ?.split( /(?=[A-Z])|[\.\-\s_]/ ) // eslint-disable-line no-useless-escape
+    .map( x => x.toLowerCase() ) ?? [];
 
   if ( parts.length === 0 ) {
     return '';
@@ -23,4 +33,21 @@ export const titleCase = ( str: string ) => {
   parts[0] = capitalize( parts[0] );
 
   return parts.reduce( ( acc, part ) => `${acc} ${part.charAt( 0 ).toUpperCase()}${part.slice( 1 )}` );
+};
+
+/**
+ * Generates a pseudorandom alphanumeric string of a given length.
+ * @param length The number of desired characters in the random string.
+ * @returns A random string value.
+ */
+export const randomString = ( length: number ) => {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+  let str = '';
+
+  for ( let i = 0; i < length; i++ ) {
+    str += chars.charAt( Math.floor( Math.random() * chars.length ) );
+  }
+
+  return str;
 };


### PR DESCRIPTION
The principal purpose of this PR is to refactor the password change functionality so that user password inputs are not transmitted to the server in plain text. Instead, the client receives a list of salts with the user's previous password hashes. The new password input is hashed with these salts client-side and all the hashes are sent to the server for comparison against previous user password hashes. Similarly, the client generates a new random salt and hashes the new password locally.

Also adds some small UI improvements, namely:

1. Obscures password text (ie. current and new password inputs) on the profile page when the input field is not in focus.
2. Clears the profile page password input fields after password is successfully changed
3. Adds a slight button hover effect to help users know when they are interacting with a button