### PR TITLE
feat(web/src/utils/files.ts): Adds additional Aprimo file types

### DIFF
--- a/serverless/utils/logs/main.go
+++ b/serverless/utils/logs/main.go
@@ -2,11 +2,16 @@ package logs
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 )
 
 // LogError formats error messages with a bespoke message and log it to CloudWatch.
 func LogError(err error, message string) {
+	if err == nil {
+		err = errors.New("unknown error")
+	}
+
 	errMessage := map[string]interface{}{
 		"Message": message,
 		"Error":   err.Error(),


### PR DESCRIPTION
Extends accepted file types to include most supported by Aprimo except 3D and some image types ([list](https://docs.google.com/spreadsheets/d/1E08p6bHR9rZMzeGpl3Mu9ZxweBKuvGzs_5Aqn-t1oFA/edit?usp=sharing)).

I have tested over a dozen types of files on the front-end, including SRT and PSD files.  I have uploaded only a few of them (including SRT and PSD), and have encountered no issues.

Also includes a fix for logging `nil` errors.