### PR TITLE
Login flow troubleshooting

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -29,6 +29,7 @@
     "curr",
     "funcs",
     "querystrings",
+    "reauth",
     "signout",
     "sitekey",
     "somepage"

--- a/serverless/funcs/creds-provision/main.go
+++ b/serverless/funcs/creds-provision/main.go
@@ -26,11 +26,12 @@ func handleInvitation(invite data.Invite) error {
 	}
 
 	pass, err := creds.SaveInitialInvite(invite, false)
+
 	if err != nil {
 		return err
 	}
 
-	err = provision.MailProvisionedCreds(invite.Invitee, pass)
+	err = provision.MailProvisionedCreds(invite.Invitee, pass, 1)
 
 	return err
 }

--- a/serverless/funcs/guest-approve/main.go
+++ b/serverless/funcs/guest-approve/main.go
@@ -41,7 +41,8 @@ func GuestAcceptHandler(ctx context.Context, event events.APIGatewayProxyRequest
 		return msgs.SendServerError(err)
 	}
 
-	err = provision.MailProvisionedCreds(invitee, pass)
+	err = provision.MailProvisionedCreds(invitee, pass, 1)
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}

--- a/serverless/funcs/guest-reauth/main.go
+++ b/serverless/funcs/guest-reauth/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/IIP-Design/commons-gateway/utils/data/guests"
 	"github.com/IIP-Design/commons-gateway/utils/email/propose"
 	"github.com/IIP-Design/commons-gateway/utils/email/provision"
+	"github.com/IIP-Design/commons-gateway/utils/logs"
 	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
 	"github.com/IIP-Design/commons-gateway/utils/security/jwt"
 
@@ -16,7 +17,7 @@ import (
 )
 
 func GuestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
-	// Need client role to determine reauth logic
+	// Need client role to determine reauthorization logic
 	scope, err := jwt.ExtractClientRole(event.Headers["Authorization"])
 	if err != nil {
 		return msgs.SendServerError(err)
@@ -25,7 +26,10 @@ func GuestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest
 	clientIsGuestAdmin := (scope == "guest admin")
 
 	guest, err := data.ExtractReauth(event.Body)
+
 	if err != nil {
+		logs.LogError(err, "Data Extraction Error")
+
 		return msgs.SendServerError(err)
 	}
 
@@ -33,8 +37,10 @@ func GuestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest
 	user, userExists, err := data.CheckForExistingUser(guest.Email, "guests")
 
 	if err != nil {
+		logs.LogError(err, "User Check Error")
 		return msgs.SendServerError(err)
 	} else if !userExists {
+		logs.LogError(err, "User Not Found Error")
 		return msgs.SendServerError(errors.New("this user has not been registered"))
 	}
 
@@ -43,12 +49,14 @@ func GuestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest
 
 	// May indicate a conflict (they have a pending request) or server error
 	if err != nil {
+		logs.LogError(err, "User Reauthorization Error")
 		return msgs.SendCustomError(err, status)
 	}
 
 	// For guest admins, we always need to email an admin to approve the new creds
 	if clientIsGuestAdmin {
 		proposer, _, err := data.CheckForExistingUser(guest.Admin, "guests")
+
 		if err != nil {
 			return msgs.SendServerError(err)
 		}
@@ -59,7 +67,8 @@ func GuestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest
 		}
 	} else if pass != "" {
 		// For admins, only send an email if they need to re-up their password
-		err = provision.MailProvisionedCreds(user, pass)
+		err = provision.MailProvisionedCreds(user, pass, 2)
+
 		if err != nil {
 			return msgs.SendServerError(err)
 		}

--- a/serverless/funcs/guest-reauth/main.go
+++ b/serverless/funcs/guest-reauth/main.go
@@ -62,6 +62,7 @@ func GuestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest
 		}
 
 		err = propose.MailProposedCreds(user, proposer)
+
 		if err != nil {
 			return msgs.SendServerError(err)
 		}

--- a/serverless/funcs/password-reset/main.go
+++ b/serverless/funcs/password-reset/main.go
@@ -23,16 +23,19 @@ func PasswordResetHandler(ctx context.Context, event events.APIGatewayProxyReque
 
 	// Ensure the user exists doesn't already have access.
 	pass, err := creds.ResetPassword(id)
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}
 
 	user, _, err := data.CheckForExistingUser(id, "guests")
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}
 
-	err = provision.MailProvisionedCreds(user, pass)
+	err = provision.MailProvisionedCreds(user, pass, 3)
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}

--- a/serverless/utils/data/creds/creds.go
+++ b/serverless/utils/data/creds/creds.go
@@ -125,7 +125,7 @@ func SaveInitialInvite(invite data.Invite, setPending bool) (string, error) {
 		email = invite.Inviter
 	}
 
-	err = invites.SaveInvite(email, invite.Invitee.Email, invite.Expires, hash, salt, setPending, true)
+	err = invites.SaveInvite(email, invite.Invitee.Email, invite.Expires, hash, salt, setPending, true, true)
 
 	if err != nil {
 		return pass, errors.New("something went wrong - saving invite failed")
@@ -141,7 +141,9 @@ func ResetPassword(email string) (string, error) {
 	pass, salt := hashing.GenerateCredentials()
 	hash := hashing.GenerateHash(pass, salt)
 
-	query := `UPDATE invites SET salt = $1, pass_hash = $2 WHERE invitee = $3 AND date_invited = ( SELECT MAX(date_invited) FROM invites WHERE invitee = $3 AND pending = FALSE );`
+	query :=
+		`UPDATE invites SET salt = $1, pass_hash = $2 WHERE invitee = $3 AND date_invited = ( SELECT MAX(date_invited)
+		 FROM invites WHERE invitee = $3 AND pending = FALSE );`
 	_, err := pool.Exec(query, salt, hash, email)
 
 	if err != nil {

--- a/serverless/utils/data/invites/invites.go
+++ b/serverless/utils/data/invites/invites.go
@@ -11,7 +11,16 @@ import (
 // saveInvite opens a database connection and records the association between an admin
 // user inviter and a guest user invitee along with the date of the invitation.
 // TODO: Document
-func SaveInvite(adminEmail string, guestEmail string, expires time.Time, hash string, salt string, setPending bool, setPasswordReset bool) error {
+func SaveInvite(
+	adminEmail string,
+	guestEmail string,
+	expires time.Time,
+	hash string,
+	salt string,
+	setPending bool,
+	setPasswordReset bool,
+	firstLogin bool,
+) error {
 	var err error
 
 	pool := data.ConnectToDB()
@@ -20,11 +29,15 @@ func SaveInvite(adminEmail string, guestEmail string, expires time.Time, hash st
 	currentTime := time.Now()
 
 	if setPending {
-		insertInvite := `INSERT INTO invites( invitee, proposer, pending, date_invited, pass_hash, salt, expiration, password_reset ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`
-		_, err = pool.Exec(insertInvite, guestEmail, adminEmail, setPending, currentTime, hash, salt, expires, setPasswordReset)
+		insertInvite :=
+			`INSERT INTO invites( invitee, proposer, pending, date_invited, pass_hash, salt, expiration, password_reset, first_login )
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);`
+		_, err = pool.Exec(insertInvite, guestEmail, adminEmail, setPending, currentTime, hash, salt, expires, setPasswordReset, firstLogin)
 	} else {
-		insertInvite := `INSERT INTO invites( invitee, inviter, pending, date_invited, pass_hash, salt, expiration, password_reset ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`
-		_, err = pool.Exec(insertInvite, guestEmail, adminEmail, setPending, currentTime, hash, salt, expires, setPasswordReset)
+		insertInvite :=
+			`INSERT INTO invites( invitee, inviter, pending, date_invited, pass_hash, salt, expiration, password_reset, first_login )
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);`
+		_, err = pool.Exec(insertInvite, guestEmail, adminEmail, setPending, currentTime, hash, salt, expires, setPasswordReset, firstLogin)
 	}
 
 	if err != nil {

--- a/web/src/pages/admin-login.astro
+++ b/web/src/pages/admin-login.astro
@@ -10,7 +10,7 @@ import oktaIcon from '/icon_okta.svg';
   import { handleAdminLogin, handleFederatedLogin } from '../utils/login';
 
   // Bypass authentication screen for authenticated users.
-  const authenticated = isLoggedInAsAdmin() || await handleAdminLogin();
+  const authenticated = isLoggedInAsAdmin() || (await handleAdminLogin());
 
   if (authenticated) {
     window.location.assign('/');
@@ -28,7 +28,7 @@ import oktaIcon from '/icon_okta.svg';
       {'Log In With Okta'}
     </Button>
   </div>
-  <a href="/partner-login" style="margin-top: 1em;">Or go to External Partner login</a>
+  <a href="/partner-login" style="margin-top: 1em;">Go to External Partner Login</a>
 </LoggedOutLayout>
 
 <style>

--- a/web/src/pages/partner-login.astro
+++ b/web/src/pages/partner-login.astro
@@ -13,6 +13,8 @@ const { PUBLIC_TURNSTILE_SITE_KEY } = import.meta.env;
   import { showError, showInfo } from '../utils/alert';
   import { handlePartnerLogin, handleMfaRequest } from '../utils/login';
   import { MONITORING_CONSENT_MESSAGE } from '../utils/constants';
+  import { toggleInputType } from '../utils/inputs';
+
   import btnStyles from '../styles/button.module.scss';
 
   // Bypass authentication screen for authenticated users.
@@ -169,7 +171,7 @@ const { PUBLIC_TURNSTILE_SITE_KEY } = import.meta.env;
       <Button id="login-btn" type="submit">Sign In</Button>
     </div>
   </form>
-  <a href="/admin-login" style="margin-top: 1em;">Or go to Admin login</a>
+  <a href="/admin-login" style="margin-top: 1em;">Go to Admin Login</a>
 </LoggedOutLayout>
 
 <style>

--- a/web/src/pages/partner-login.astro
+++ b/web/src/pages/partner-login.astro
@@ -83,9 +83,9 @@ const { PUBLIC_TURNSTILE_SITE_KEY } = import.meta.env;
   submitBtn?.addEventListener('click', async (e) => {
     e.preventDefault();
 
-    const name = nameInput.value;
-    const pass = passInput.value;
-    const mfa = mfaInput.value;
+    const name = nameInput.value.trim();
+    const pass = passInput.value.trim();
+    const mfa = mfaInput.value.trim();
 
     // Empty string if not using token in deployment, null if using and missing
     const token = tokenInput.length ? tokenInput[0].value || null : '';

--- a/web/src/pages/partner-login.astro
+++ b/web/src/pages/partner-login.astro
@@ -52,6 +52,10 @@ const { PUBLIC_TURNSTILE_SITE_KEY } = import.meta.env;
     'cf-turnstile-response'
   ) as NodeListOf<HTMLInputElement>;
 
+  // Toggle the visibility of the password input fields when they are selected/deselected.
+  passInput?.addEventListener('focus', toggleInputType);
+  passInput?.addEventListener('blur', toggleInputType);
+
   // Initialize a variable store the MFA request id.
   let mfaRequestId = '';
 

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -115,7 +115,7 @@ const desc = 'Because this is your first login with this invite, you must update
     try {
       const [saltData] = await getUserPasswordSalt(email);
 
-      const { salt, prevSalts } = saltData;
+      const { salt, prevSalts } = saltData || {};
 
       const currentPasswordHash = await derivePasswordHash(currPassword, salt);
 

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -65,8 +65,8 @@ const desc = 'Because this is your first login with this invite, you must update
     const email = user.email || '';
     const role = user.role || '';
 
-    const currPassword = currPassElem.value;
-    const newPassword = newPassElem.value;
+    const currPassword = currPassElem.value.trim();
+    const newPassword = newPassElem.value.trim();
 
     return { email, role, currPassword, newPassword };
   };

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -18,6 +18,7 @@ const desc = 'Because this is your first login with this invite, you must update
   import { derivePasswordHash } from '../utils/hashing';
   import { buildQuery } from '../utils/api';
   import { randomString } from '../utils/string';
+  import { toggleInputType } from '../utils/inputs';
 
   interface ISubData {
     email: string;
@@ -25,22 +26,6 @@ const desc = 'Because this is your first login with this invite, you must update
     currPassword: string;
     newPassword: string;
   }
-
-  /**
-   * Switch the input fields from passwords to text when in focus.
-   * @param el The input element in question.
-   */
-  const toggleInputType = (el: FocusEvent) => {
-    const { type, target } = el;
-    const { id } = target as HTMLInputElement;
-
-    const inputType = type === 'focus' ? 'text' : 'password';
-
-    if (id) {
-      const input = document.getElementById(id) as HTMLInputElement;
-      input.type = inputType;
-    }
-  };
 
   // Toggle the visibility of the password input fields when they are selected/deselected.
   const inputs = document.querySelectorAll('input');

--- a/web/src/pages/profile.astro
+++ b/web/src/pages/profile.astro
@@ -113,7 +113,10 @@ const desc = 'Because this is your first login with this invite, you must update
     const isFirstLogin = loginStatus.get() === 'firstLogin';
 
     try {
-      const [{ salt, prevSalts }] = await getUserPasswordSalt(email);
+      const [saltData] = await getUserPasswordSalt(email);
+
+      const { salt, prevSalts } = saltData;
+
       const currentPasswordHash = await derivePasswordHash(currPassword, salt);
 
       // Derive the hash of the new password with previously used salts.

--- a/web/src/utils/inputs.ts
+++ b/web/src/utils/inputs.ts
@@ -1,0 +1,16 @@
+/**
+ * Switch the input fields from passwords to text when in focus.
+ * @param el The input element in question.
+ */
+export const toggleInputType = ( el: FocusEvent ) => {
+  const { type, target } = el;
+  const { id } = target as HTMLInputElement;
+
+  const inputType = type === 'focus' ? 'text' : 'password';
+
+  if ( id ) {
+    const input = document.getElementById( id ) as HTMLInputElement;
+
+    input.type = inputType;
+  }
+};

--- a/web/src/utils/login.ts
+++ b/web/src/utils/login.ts
@@ -143,13 +143,13 @@ export const handlePartnerLogin = async ( username: string, password: string, mf
   let authenticated = false;
 
   try {
-    const [{ salt }, saltError] = await getUserPasswordSalt( username );
+    const [saltData, saltError] = await getUserPasswordSalt( username );
 
-    if ( !salt ) {
+    if ( !saltData?.salt ) {
       return [authenticated, saltError];
     }
 
-    const localHash = await derivePasswordHash( password, salt );
+    const localHash = await derivePasswordHash( password, saltData.salt );
     const jwt = await submitUserPasswordHash( localHash, username, mfa, token );
 
     if ( !jwt ) {


### PR DESCRIPTION
Addresses several issues raised in the 11/09 login troubleshooting session:

- Trims the user inputs from the profile page (current and new password fields) and partner login page (email, password, and mfa code). This prevents the accidental inclusion of errant white space if copying the value from elsewhere.
- Reveals the contents of the password field on the partner-login page when the field is in focus.
- Waits to clear the 2FA entries until all credential checks complete. This allows the user to correct an incorrect password and reattempt a login without requesting a new 2FA code.
- Fixes an error with the `handlePartnerLogin` function wherein the presence of a salt value is assumed. Now uses optional chaining rather than destructuring to safely access this property. This resolves the reported issue wherein the account lockout message was not properly displaying.
- Makes the email sent to users with their temporary password configurable so that the subject line and email text are more relevant in cases other than account creations (ie. password resets and account reactivations)
- Sets `first_login` to true whenever a user reauthorization requires a user's email to be reset (ie. re-provisioned temp credentials). This in turn should redirect that user to the profile page to force a password change.
- Incidentally, adds some error logging.