### PR TITLE
Bug fixes

### DIFF
--- a/serverless/funcs/creds-provision/main.go
+++ b/serverless/funcs/creds-provision/main.go
@@ -31,7 +31,7 @@ func handleInvitation(invite data.Invite) error {
 		return err
 	}
 
-	_, err = provision.MailProvisionedCreds(invite.Invitee, pass, 1)
+	_, err = provision.MailProvisionedCreds(invite.Invitee, pass, 0)
 
 	return err
 }

--- a/serverless/funcs/guest-approve/main.go
+++ b/serverless/funcs/guest-approve/main.go
@@ -42,7 +42,7 @@ func guestAcceptHandler(ctx context.Context, event events.APIGatewayProxyRequest
 		return msgs.SendServerError(err)
 	}
 
-	_, err = provision.MailProvisionedCreds(invitee, pass, 1)
+	_, err = provision.MailProvisionedCreds(invitee, pass, 0)
 	if err != nil {
 		return msgs.SendServerError(err)
 	}

--- a/serverless/funcs/guest-approve/main.go
+++ b/serverless/funcs/guest-approve/main.go
@@ -43,6 +43,7 @@ func guestAcceptHandler(ctx context.Context, event events.APIGatewayProxyRequest
 	}
 
 	_, err = provision.MailProvisionedCreds(invitee, pass, 0)
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}

--- a/serverless/funcs/guest-reauth/main.go
+++ b/serverless/funcs/guest-reauth/main.go
@@ -71,7 +71,8 @@ func guestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest
 		}
 	} else if pass != "" {
 		// For admins, only send an email if they need to re-up their password
-		_, err = provision.MailProvisionedCreds(user, pass, 2)
+		_, err = provision.MailProvisionedCreds(user, pass, 1)
+
 		if err != nil {
 			return msgs.SendServerError(err)
 		}

--- a/serverless/funcs/guest-reauth/main.go
+++ b/serverless/funcs/guest-reauth/main.go
@@ -20,6 +20,7 @@ import (
 func guestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest) (msgs.Response, error) {
 	// Need client role to determine reauthorization logic
 	scope, err := jwt.ExtractClientRole(event.Headers["Authorization"])
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}

--- a/serverless/funcs/password-change/main.go
+++ b/serverless/funcs/password-change/main.go
@@ -6,14 +6,15 @@ import (
 	"errors"
 	"time"
 
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/rs/xid"
+
 	"github.com/IIP-Design/commons-gateway/utils/data/creds"
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
 	"github.com/IIP-Design/commons-gateway/utils/data/users"
 	"github.com/IIP-Design/commons-gateway/utils/logs"
 	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/rs/xid"
 )
 
 type PasswordReset struct {
@@ -43,6 +44,7 @@ func verifyUser(parsed PasswordReset) (creds.CredentialsData, error) {
 	var credentials creds.CredentialsData
 
 	_, exists, err := users.CheckForExistingUser(parsed.Email, "guests")
+
 	if err != nil || !exists {
 		return credentials, errors.New("user does not exist")
 	}

--- a/serverless/funcs/password-reset/main.go
+++ b/serverless/funcs/password-reset/main.go
@@ -36,7 +36,8 @@ func passwordResetHandler(ctx context.Context, event events.APIGatewayProxyReque
 		return msgs.SendServerError(err)
 	}
 
-	_, err = provision.MailProvisionedCreds(user, pass, 3)
+	_, err = provision.MailProvisionedCreds(user, pass, 2)
+
 	if err != nil {
 		return msgs.SendServerError(err)
 	}

--- a/serverless/utils/data/creds/creds.go
+++ b/serverless/utils/data/creds/creds.go
@@ -135,6 +135,9 @@ func SaveInitialInvite(invite data.Invite, setPending bool) (string, error) {
 	return pass, nil
 }
 
+// ResetPassword assigns a given user a new random temporary password. It allows
+// records this as the user's first login so that they are required to update their
+// password upon their next login.
 func ResetPassword(email string) (string, error) {
 	pool := data.ConnectToDB()
 	defer pool.Close()
@@ -143,8 +146,8 @@ func ResetPassword(email string) (string, error) {
 	hash := hashing.GenerateHash(pass, salt)
 
 	query :=
-		`UPDATE invites SET salt = $1, pass_hash = $2 WHERE invitee = $3 AND date_invited = ( SELECT MAX(date_invited)
-		 FROM invites WHERE invitee = $3 AND pending = FALSE );`
+		`UPDATE invites SET salt = $1, pass_hash = $2, first_login = TRUE WHERE invitee = $3
+		 AND date_invited = ( SELECT MAX(date_invited) FROM invites WHERE invitee = $3 AND pending = FALSE );`
 	_, err := pool.Exec(query, salt, hash, email)
 
 	if err != nil {

--- a/serverless/utils/data/guests/guests.go
+++ b/serverless/utils/data/guests/guests.go
@@ -241,8 +241,8 @@ func RetrieveUploaders(team string) ([]map[string]any, error) {
 			"team":        guest.Team,
 			"expires":     guest.Expires,
 			"dateInvited": guest.DateInvited,
-			"proposer":    guest.Proposer,
-			"inviter":     guest.Inviter,
+			"proposer":    guest.Proposer.String,
+			"inviter":     guest.Inviter.String,
 			"pending":     guest.Pending,
 		}
 

--- a/serverless/utils/email/provision/provision.go
+++ b/serverless/utils/email/provision/provision.go
@@ -105,19 +105,19 @@ func formatEmail(invitee data.User, tmpPassword string, url string, sourceEmail 
 // into the external partner portal. For the action parameter, pass in an integer corresponding
 // to one of the credential provisioning actions. There are three enumerated action types:
 //
-//	1 - used when creating a new account
-//	2 - used when reauthorizing an existing expired account
-//	3 - used when resetting an existing account password
+//	0 - used when creating a new account
+//	1 - used when reauthorizing an existing expired account
+//	2 - used when resetting an existing account password
 func MailProvisionedCreds(invitee data.User, tmpPassword string, action ProvisionType) (string, error) {
 	var err error
-	var mesageId string
+	var messageId string
 
 	sourceEmail := os.Getenv("SOURCE_EMAIL_ADDRESS")
 	redirectUrl := os.Getenv("EMAIL_REDIRECT_URL")
 
 	if sourceEmail == "" {
 		logs.LogError(errors.New("not configured for sending emails"), "Source Email Empty Error")
-		return mesageId, err
+		return messageId, err
 	}
 
 	awsRegion := os.Getenv("AWS_SES_REGION")
@@ -126,7 +126,7 @@ func MailProvisionedCreds(invitee data.User, tmpPassword string, action Provisio
 
 	if err != nil {
 		logs.LogError(err, "Error Loading AWS Config")
-		return mesageId, err
+		return messageId, err
 	}
 
 	sesClient := ses.NewFromConfig(cfg)
@@ -140,11 +140,12 @@ func MailProvisionedCreds(invitee data.User, tmpPassword string, action Provisio
 	)
 
 	resp, err := sesClient.SendEmail(context.TODO(), &e)
+
 	if err != nil {
 		logs.LogError(err, "Credentials Provisioning Email Error")
 	}
 
-	mesageId = *resp.MessageId
+	messageId = *resp.MessageId
 
-	return mesageId, err
+	return messageId, err
 }

--- a/web/src/components/UploaderTable.tsx
+++ b/web/src/components/UploaderTable.tsx
@@ -71,19 +71,11 @@ const UploaderTable: FC = () => {
       defaultColumnDef( 'email' ),
       {
         ...defaultColumnDef( 'proposer' ),
-        cell: info => {
-          const { String, Valid } = info.getValue() as any;
-
-          return Valid ? String : null;
-        },
+        cell: info => info.row.getValue( 'proposer' ),
       },
       {
         ...defaultColumnDef( 'inviter' ),
-        cell: info => {
-          const { String, Valid } = info.getValue() as any;
-
-          return Valid ? String : null;
-        },
+        cell: info => info.row.getValue( 'inviter' ),
       },
       {
         ...defaultColumnDef( 'active', 'Status' ),

--- a/web/src/components/UploaderTable.tsx
+++ b/web/src/components/UploaderTable.tsx
@@ -83,11 +83,13 @@ const UploaderTable: FC = () => {
           const isPending = info.row.original.pending as boolean;
           const isActive = info.getValue() as boolean;
 
+          const baseStyle = isPending ? style.pending : style.active;
+          const baseLabel = isPending ? 'Pending' : 'Active';
 
           return (
             <span className={ style.status }>
-              <span className={ isActive ? ( isPending ? style.pending : style.active ) : style.inactive } />
-              { isActive ? ( isPending ? 'Pending' : 'Active' ) : 'Inactive' }
+              <span className={ isActive ? baseStyle : style.inactive } />
+              { isActive ? baseLabel : 'Inactive' }
             </span>
           );
         },

--- a/web/src/styles/button.module.scss
+++ b/web/src/styles/button.module.scss
@@ -64,6 +64,10 @@
   padding: 0!important;
   text-decoration: underline;
   cursor: pointer;
+
+  @include breakpoint('tablet') {
+    font-size:var(--fontSizeNormal);
+  }
 }
 
 .anchor-btn {

--- a/web/src/styles/button.module.scss
+++ b/web/src/styles/button.module.scss
@@ -11,11 +11,6 @@
   border: none;
   background-color: var(--blue);
   color: #ffffff;
-
-  &:not(:disabled):not(:active):hover {
-    box-shadow: 2px 1px 3px 2px var(--greyLight);
-    transform: translate(-1px)
-  }
 }
 
 .btn-light {
@@ -23,6 +18,15 @@
   border: 1px solid var(--blue);
   background-color: #ffffff;
   color: var(--blue);
+}
+
+.btn,
+.btn:visited,
+.btn-light {
+  &:not(:disabled):not(:active):hover {
+    box-shadow: 2px 1px 3px 2px var(--greyLight);
+    transform: translate(-1px)
+  }
 }
 
 .btn-pair {


### PR DESCRIPTION
This PR is comprised of a few small changes focused on bugs reported during QA.

1. Sets an invite's `first_login` value to `true` when a user's password is reset. This forces the user to update their password from the randomly generated temp value.
2. Fixes the numbering for the `action` value in each instance of `MailProvisionedCreds` to ensure that the user receives the correct email message.
3. Returns only the proposer/inviters name on the uploaders request so that the values can be sorted in the table.