### PR TITLE
fix(web): Table accessibility issue, misc linter errors

### DIFF
--- a/web/src/components/AdminForm.tsx
+++ b/web/src/components/AdminForm.tsx
@@ -116,7 +116,9 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
       showError( 'Email address is not valid' );
 
       return false;
-    } if ( !adminData.team ) {
+    }
+
+    if ( !adminData.team ) {
       showError( 'Please assign this user to a valid team' );
 
       return false;

--- a/web/src/components/BackButton.tsx
+++ b/web/src/components/BackButton.tsx
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////
 // React Imports
 // ////////////////////////////////////////////////////////////////////////////
 import type { FC } from 'react';
@@ -11,35 +11,35 @@ import { showConfirm } from '../utils/alert';
 // ////////////////////////////////////////////////////////////////////////////
 // Styles and CSS
 // ////////////////////////////////////////////////////////////////////////////
-import styles from '../styles/button.module.scss'
+import styles from '../styles/button.module.scss';
 
 // ////////////////////////////////////////////////////////////////////////////
 // Interfaces and Types
 // ////////////////////////////////////////////////////////////////////////////
 interface IBackButtonProps {
-    id?: string;
-    text?: string;
-    showConfirmDialog?: boolean;
+    readonly id?: string;
+    readonly text?: string;
+    readonly showConfirmDialog?: boolean;
 }
 
 // ////////////////////////////////////////////////////////////////////////////
 // Implementation
 // ////////////////////////////////////////////////////////////////////////////
 const BackButton: FC<IBackButtonProps> = ( { id, text, showConfirmDialog }: IBackButtonProps ) => {
-    const goBack = () => {
-        if( showConfirmDialog ) {
-            showConfirm( "Are you sure you want to return to the previous page?  You will lose all unsaved progress." )
-                .then( ( result ) => {
-                    if( result.isConfirmed ) {
-                        window.history.back();
-                    }
-                } );
-        } else {
-          window.history.back();
-        }
+  const goBack = () => {
+    if ( showConfirmDialog ) {
+      showConfirm( 'Are you sure you want to return to the previous page?  You will lose all unsaved progress.' )
+        .then( result => {
+          if ( result.isConfirmed ) {
+            window.history.back();
+          }
+        } );
+    } else {
+      window.history.back();
     }
+  };
 
-    return <button id={ id || "back-btn"} type="button" onClick={goBack} className={`${styles.btn} ${styles['back-btn']} ${styles['spaced-btn']}`}>{ text || "Back"}</button>
-}
+  return <button id={ id || 'back-btn' } type="button" onClick={ goBack } className={ `${styles.btn} ${styles['back-btn']} ${styles['spaced-btn']}` }>{ text || 'Back' }</button>;
+};
 
 export default BackButton;

--- a/web/src/components/EditUserForm.tsx
+++ b/web/src/components/EditUserForm.tsx
@@ -46,6 +46,19 @@ interface IInviteWidgetParams {
   readonly isAdmin: boolean;
 }
 
+// Possible TODO: Remove
+interface IRawInvite {
+  proposer?: {
+    String: string;
+    Valid: boolean;
+  },
+  pending: boolean;
+  expired: boolean;
+  passwordReset: boolean;
+  dateInvited: string;
+  expiration: string;
+}
+
 // ////////////////////////////////////////////////////////////////////////////
 // Helpers
 // ////////////////////////////////////////////////////////////////////////////
@@ -211,54 +224,50 @@ const CurrentInvite: FC<IInviteWidgetParams> = ( { userData, invite, isAdmin }: 
   );
 };
 
-const PendingInvite: FC<IInviteWidgetParams> = ( { userData: { email }, invite, isAdmin }: IInviteWidgetParams ) => {
-  const [pendingInvite] = useState<IInvite>( invite );
-
-  return (
-    <div id="invite-data-form">
-      <h3>Proposed Access</h3>
-      <div className="field-group">
-        <label>
-          <span>Access End Date</span>
-          <input
-            id="date-input"
-            type="date"
-            disabled
-            value={ pendingInvite.accessEndDate }
-          />
-        </label>
-        <label>
-          <span>Date Invited</span>
-          <input
-            id="date-invited-input"
-            type="date"
-            disabled
-            value={ pendingInvite.dateInvited }
-          />
-        </label>
-      </div>
-      {
-        isAdmin
-          ? (
-            <button
-              className={ `${btnStyles['btn-light']}` }
-              id="finalize-btn"
-              type="button"
-              onClick={ makeApproveUserHandler( email ) }
-            >
-              Finalize
-            </button>
-          )
-          : (
-            <p>
-              { `Proposed by ${pendingInvite.proposer || 'N/A'}` }
-            </p>
-          )
-      }
-
+const PendingInvite: FC<IInviteWidgetParams> = ( { userData: { email }, invite, isAdmin }: IInviteWidgetParams ) => (
+  <div id="invite-data-form">
+    <h3>Proposed Access</h3>
+    <div className="field-group">
+      <label>
+        <span>Access End Date</span>
+        <input
+          id="date-input"
+          type="date"
+          disabled
+          value={ invite.accessEndDate }
+        />
+      </label>
+      <label>
+        <span>Date Invited</span>
+        <input
+          id="date-invited-input"
+          type="date"
+          disabled
+          value={ invite.dateInvited }
+        />
+      </label>
     </div>
-  );
-};
+    {
+      isAdmin
+        ? (
+          <button
+            className={ `${btnStyles['btn-light']}` }
+            id="finalize-btn"
+            type="button"
+            onClick={ makeApproveUserHandler( email ) }
+          >
+            Finalize
+          </button>
+        )
+        : (
+          <p>
+            { `Proposed by ${invite.proposer || 'N/A'}` }
+          </p>
+        )
+    }
+
+  </div>
+);
 
 // ////////////////////////////////////////////////////////////////////////////
 // Interface and Implementation
@@ -312,7 +321,7 @@ const UserForm: FC = () => {
           accessEndDate: getYearMonthDay( parse( data.expiration, "yyyy-MM-dd'T'HH:mm:ssX", new Date() ) ),
         } );
 
-        const fmtInvites: IInvite[] = data.invites.map( ( invite: any ) => ( {
+        const fmtInvites: IInvite[] = data.invites.map( ( invite: IRawInvite ) => ( {
           proposer: invite.proposer?.String || null,
           pending: invite.pending,
           expired: invite.expired,

--- a/web/src/components/InviteModal.tsx
+++ b/web/src/components/InviteModal.tsx
@@ -27,55 +27,53 @@ interface IModalProps {
 // ////////////////////////////////////////////////////////////////////////////
 // Interfaces and Types
 // ////////////////////////////////////////////////////////////////////////////
-const InviteEntry = ( invite: IInvite, idx: number ) => {
-  return (
-    <div key={`${invite.dateInvited}-${idx}`}>
-      <hr style={{marginTop: '10px'}} />
-      <div className="field-group">
-        <label>
-          <span>Invite Date</span>
-          <input
-            type="date"
-            disabled
-            value={invite.dateInvited}
-          />
-        </label>
-        <label>
-          <span>Access End Date</span>
-          <input
-            type="date"
-            disabled
-            value={invite.accessEndDate}
-          />
-        </label>
-      </div>
-      <table className={`${tableStyles.table}`}>
-        <thead>
-          <tr>
-            <th>Status</th>
-            <th>Result</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-            <span className={ tableStyles.status }>
-              <span className={ !invite.pending ? tableStyles.active : tableStyles.inactive } />
-              { invite.pending ? 'Pending' : 'Approved' }
-            </span>
-            </td>
-            <td>
-            <span className={ tableStyles.status }>
-              <span className={ !invite.expired ? tableStyles.active : tableStyles.inactive } />
-              { invite.expired ? 'Expired' : 'Current' }
-            </span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+const InviteEntry = ( { dateInvited, accessEndDate, pending, expired }: IInvite, idx: number ) => (
+  <div key={ `${dateInvited}-${idx}` }>
+    <hr style={ { marginTop: '10px' } } />
+    <div className="field-group">
+      <label>
+        <span>Invite Date</span>
+        <input
+          type="date"
+          disabled
+          value={ dateInvited }
+        />
+      </label>
+      <label>
+        <span>Access End Date</span>
+        <input
+          type="date"
+          disabled
+          value={ accessEndDate }
+        />
+      </label>
     </div>
-  );
-}
+    <table className={ `${tableStyles.table}` }>
+      <thead>
+        <tr>
+          <th>Status</th>
+          <th>Result</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span className={ tableStyles.status }>
+              <span className={ !pending ? tableStyles.active : tableStyles.inactive } />
+              { pending ? 'Pending' : 'Approved' }
+            </span>
+          </td>
+          <td>
+            <span className={ tableStyles.status }>
+              <span className={ !expired ? tableStyles.active : tableStyles.inactive } />
+              { expired ? 'Expired' : 'Current' }
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+);
 
 // ////////////////////////////////////////////////////////////////////////////
 // Config
@@ -116,10 +114,10 @@ export const InviteModal: FC<IModalProps> = ( { invites, anchor }: IModalProps )
   return (
     <>
       <button
-        className={ `${btnStyle.btn} ${noHistory ? btnStyle['disabled-btn'] : ""}` }
+        className={ `${btnStyle.btn} ${noHistory ? btnStyle['disabled-btn'] : ''}` }
         onClick={ openModal }
         type="button"
-        disabled={noHistory}
+        disabled={ noHistory }
       >
         { anchor }
       </button>
@@ -130,11 +128,9 @@ export const InviteModal: FC<IModalProps> = ( { invites, anchor }: IModalProps )
         style={ modalStyle }
       >
         <h3>Invite History</h3>
-        {
-            invites.slice(0).map( ( invite, idx ) => InviteEntry( invite, idx ) )
-        }
+        { invites.slice( 0 ).map( ( invite, idx ) => InviteEntry( invite, idx ) ) }
         <button
-          className={btnStyle.btn}
+          className={ btnStyle.btn }
           onClick={ closeModal }
           type="button"
         >

--- a/web/src/components/NewUserForm.tsx
+++ b/web/src/components/NewUserForm.tsx
@@ -91,11 +91,15 @@ const UserForm: FC = () => {
       showError( 'Email address is not valid' );
 
       return false;
-    } if ( !dateSelectionIsValid( userData.accessEndDate ) ) {
+    }
+
+    if ( !dateSelectionIsValid( userData.accessEndDate ) ) {
       showError( `Please select an access grant end date after today and no more than ${MAX_ACCESS_GRANT_DAYS} in the future` );
 
       return false;
-    } if ( isAdmin && !userData.team ) {
+    }
+
+    if ( isAdmin && !userData.team ) {
       // Admin users have the option to set a team, so a team should be
       showError( 'Please assign this user to a valid team' );
 
@@ -147,7 +151,7 @@ const UserForm: FC = () => {
       try {
         await buildQuery( 'creds/propose', invitation, 'POST' );
         window.location.assign( '/uploader-users' );
-      } catch ( err: any ) {
+      } catch ( err ) {
         console.error( err );
       }
     }

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -14,7 +14,7 @@ import {
   flexRender,
   getSortedRowModel,
 } from '@tanstack/react-table';
-import type { Column, Table as ReactTable, ColumnDef, SortingState } from '@tanstack/react-table';
+import type { Column, Table as ReactTable, ColumnDef, SortingState, Header } from '@tanstack/react-table';
 
 // ////////////////////////////////////////////////////////////////////////////
 // Local Imports
@@ -24,7 +24,7 @@ import { titleCase } from '../utils/string';
 // ////////////////////////////////////////////////////////////////////////////
 // Styles and CSS
 // ////////////////////////////////////////////////////////////////////////////
-import style from '../styles/table.module.scss';
+import tableStyles from '../styles/table.module.scss';
 
 // ////////////////////////////////////////////////////////////////////////////
 // Types and Interfaces
@@ -54,8 +54,8 @@ export const Filter = ( {
   column,
   table,
 }: {
-  column: Column<any, any>
-  table: ReactTable<any>
+  column: Column<any, any>  // eslint-disable-line @typescript-eslint/no-explicit-any
+  table: ReactTable<any>    // eslint-disable-line @typescript-eslint/no-explicit-any
 } ) => {
   const skipFiltering = ( column.id.startsWith( '_' ) );
 
@@ -117,9 +117,9 @@ export const Filter = ( {
 };
 
 export const PaginationFooter = <T, >( { table }: { readonly table: ReactTable<T> } ) => (
-  <div className={ style['pagination-footer'] }>
+  <div className={ tableStyles['pagination-footer'] }>
     <button
-      className={ style['pagination-button'] }
+      className={ tableStyles['pagination-button'] }
       onClick={ () => table.setPageIndex( 0 ) }
       disabled={ !table.getCanPreviousPage() }
       type="button"
@@ -127,21 +127,21 @@ export const PaginationFooter = <T, >( { table }: { readonly table: ReactTable<T
       { '<<' }
     </button>
     <button
-      className={ style['pagination-button'] }
+      className={ tableStyles['pagination-button'] }
       onClick={ () => table.previousPage() }
       disabled={ !table.getCanPreviousPage() }
       type="button"
     >
       { '<' }
     </button>
-    <span className={ style['go-to-page-container'] }>
+    <span className={ tableStyles['go-to-page-container'] }>
       <div style={ { display: 'inline' } }>Page</div>
       <strong>
         { `${table.getState().pagination.pageIndex + 1} of ${table.getPageCount()}` }
       </strong>
     </span>
     <button
-      className={ style['pagination-button'] }
+      className={ tableStyles['pagination-button'] }
       onClick={ () => table.nextPage() }
       disabled={ !table.getCanNextPage() }
       type="button"
@@ -149,18 +149,18 @@ export const PaginationFooter = <T, >( { table }: { readonly table: ReactTable<T
       { '>' }
     </button>
     <button
-      className={ style['pagination-button'] }
+      className={ tableStyles['pagination-button'] }
       onClick={ () => table.setPageIndex( table.getPageCount() - 1 ) }
       disabled={ !table.getCanNextPage() }
       type="button"
     >
       { '>>' }
     </button>
-    <span className={ style['go-to-page-container'] }>
+    <span className={ tableStyles['go-to-page-container'] }>
       { 'Go to page: ' }
       <input
         aria-label="Go to page"
-        className={ style['page-num-select'] }
+        className={ tableStyles['page-num-select'] }
         id="goto-page-number-input"
         defaultValue={ table.getState().pagination.pageIndex + 1 }
         max={ table.getPageCount() }
@@ -173,11 +173,11 @@ export const PaginationFooter = <T, >( { table }: { readonly table: ReactTable<T
         } }
       />
     </span>
-    <span className={ style['go-to-page-container'] }>
+    <span className={ tableStyles['go-to-page-container'] }>
       { 'Show ' }
       <select
         aria-label="Select number of results per page"
-        className={ style['page-show-select'] }
+        className={ tableStyles['page-show-select'] }
         id="show-page-number-select"
         style={ { width: 'auto', marginLeft: '0.375em', marginRight: '0.375em' } }
         value={ table.getState().pagination.pageSize }
@@ -204,6 +204,16 @@ export const PaginationFooter = <T, >( { table }: { readonly table: ReactTable<T
 export const Table = <DataType, >( { data, columns, additionalTableClasses }: ITableProps<DataType> ) => {
   const [sorting, setSorting] = useState<SortingState>( [] );
 
+  const makeHeaderKeyDownHandler = ( header: Header<DataType, unknown> ) => {
+    const handler = header.column.getToggleSortingHandler();
+
+    return ( e: React.KeyboardEvent ) => {
+      if ( e.key === 'Enter' && handler ) {
+        handler( e );
+      }
+    };
+  };
+
   const table = useReactTable<DataType>( {
     data,
     columns,
@@ -218,12 +228,12 @@ export const Table = <DataType, >( { data, columns, additionalTableClasses }: IT
     getSortedRowModel: getSortedRowModel(),
   } );
 
-  const tableClasses = ( additionalTableClasses || [] ).map( c => style[c] ).filter( Boolean )
+  const tableClasses = ( additionalTableClasses || [] ).map( c => tableStyles[c] ).filter( Boolean )
     .join( ' ' );
 
   return (
-    <div className={ style.container }>
-      <table className={ `${style.table} ${tableClasses}` }>
+    <div className={ tableStyles.container }>
+      <table className={ `${tableStyles.table} ${tableClasses}` }>
         <thead>
           { table.getHeaderGroups().map( headerGroup => (
             <tr key={ headerGroup.id }>
@@ -233,13 +243,19 @@ export const Table = <DataType, >( { data, columns, additionalTableClasses }: IT
                     ? null
                     : (
                       <div
-                        className={ header.column.getCanSort() ? style['sortable-header'] : '' }
-                        onClick={ header.column.getToggleSortingHandler() }
+                        className={ header.column.getCanSort() ? tableStyles['sortable-header'] : '' }
                       >
-                        { flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        ) }
+                        <span
+                          onClick={ header.column.getToggleSortingHandler() }
+                          onKeyDown={ makeHeaderKeyDownHandler( header ) }
+                          role="button"
+                          tabIndex={ 0 }
+                        >
+                          { flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          ) }
+                        </span>
                         { {
                           asc: ' 🔺',
                           desc: ' 🔻',

--- a/web/src/components/TeamModal/TeamModal.tsx
+++ b/web/src/components/TeamModal/TeamModal.tsx
@@ -1,7 +1,7 @@
 // ////////////////////////////////////////////////////////////////////////////
 // React Imports
 // ////////////////////////////////////////////////////////////////////////////
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import type{ FC } from 'react';
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -57,7 +57,7 @@ export const TeamModal: FC<ITeamModalProps> = ( { team, setTeams, anchor }: ITea
   };
 
   // Update Controls
-  const handleUpdate = ( key: string, value: any ) => {
+  const handleUpdate = ( key: keyof ITeam, value: ValueOf<ITeam> ) => {
     setLocalTeam( { ...localTeam, [key]: value } );
   };
 

--- a/web/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/web/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -14,7 +14,7 @@ const ToggleSwitch: FC<IToggleSwitchProps> = ( { id, active, toggleable, callbac
   const [toggled, setToggled] = useState( active );
 
   const handleToggle = () => {
-    if( !(toggleable ?? true) ) {
+    if ( !( toggleable ?? true ) ) {
       return;
     }
 

--- a/web/src/components/UserTable.tsx
+++ b/web/src/components/UserTable.tsx
@@ -92,13 +92,16 @@ const UserTable: FC<IUserTableProps> = ( { role }: IUserTableProps ) => {
       {
         ...defaultColumnDef( 'active', 'Status' ),
         cell: info => {
-          const isPending = info.row.original["pending"] as boolean;
+          const isPending = info.row.original.pending as boolean;
           const isActive = info.getValue() as boolean;
+
+          const baseStyle = isPending ? style.pending : style.active;
+          const baseLabel = isPending ? 'Pending' : 'Active';
 
           return (
             <span className={ style.status }>
-              <span className={ isActive ? ( isPending ? style.pending : style.active ) : style.inactive } />
-              { isPending ? 'Pending' : ( isActive ? 'Active' : 'Inactive' ) }
+              <span className={ isActive ? baseStyle : style.inactive } />
+              { isActive ? baseLabel : 'Inactive' }
             </span>
           );
         },

--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -1,6 +1,7 @@
 declare module '*.scss';
 
 type Nullable<T> = T | null;
+type ValueOf<T> = T[keyof T];
 
 interface ITeam {
   id: string

--- a/web/src/utils/arrays.ts
+++ b/web/src/utils/arrays.ts
@@ -9,7 +9,5 @@
 export const selectSlice = ( arr: any[], count: number, offset: number ) => {
   const startingIndex = offset * count;
 
-  const selection = arr.slice( startingIndex, startingIndex + count );
-
-  return selection;
+  return arr.slice( startingIndex, startingIndex + count );
 };

--- a/web/src/utils/dates.ts
+++ b/web/src/utils/dates.ts
@@ -11,7 +11,10 @@ export const getYearMonthDay = ( date: Date ) => {
   const month = date.getMonth() + 1; // Add one to adjust for zero indexing.
   const day = date.getDate();
 
-  return `${year}-${month > 9 ? month : `0${month}`}-${day > 9 ? day : `0${day}`}`;
+  const fmtMonth = month > 9 ? month : `0${month}`;
+  const fmtDay = day > 9 ? day : `0${day}`;
+
+  return `${year}-${fmtMonth}-${fmtDay}`;
 };
 
 /**


### PR DESCRIPTION
This PR mainly intends to fix two issues:

- Sorting tables has a bug in that clicking into the filter input field causes the column to sort, because the `onClick` hander is attached to the common parent element
- Sorting is not accessible because functionality is attached to a static element

The fix requires two steps:

- Move the event handler into the header text only (this was the intended functionality)
- Add interactivity support to achieve A11y compatibility

Currently the sort fires only on the "enter" key when the text has focus, since accepting any key lead to sorting on tab out.  Potentially a subset of keys is a better option.

-------

Also corrects misc. linter issues; apparently my linter has not been working correctly for a while.