### PR TITLE
Improved User Checking [CC20P-122]

### DIFF
--- a/serverless/funcs/admin-deactivate/main.go
+++ b/serverless/funcs/admin-deactivate/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -41,17 +42,22 @@ func deactivateAdminHandler(ctx context.Context, event events.APIGatewayProxyReq
 	}
 
 	// Ensure that the user we intend to modify exists.
-	_, exists, err := users.CheckForExistingUser(username, "admins")
+	_, exists, err := users.CheckForExistingAdminUser(username)
 
 	if !exists {
-		return msgs.SendCustomError(errors.New("admin does not exist"), 404)
+		err = fmt.Errorf("%s does not exist as an admin user", username)
+
+		logs.LogError(err, "Deactivate Admin Error")
+		return msgs.SendCustomError(err, 404)
 	} else if err != nil {
+		logs.LogError(err, "Deactivate Admin Error")
 		return msgs.SendServerError(err)
 	}
 
 	err = deactivateAdmin(username)
 
 	if err != nil {
+		logs.LogError(err, "Deactivate Admin Error")
 		return msgs.SendServerError(err)
 	}
 

--- a/serverless/funcs/admin-get/main.go
+++ b/serverless/funcs/admin-get/main.go
@@ -32,7 +32,7 @@ func getAdminHandler(ctx context.Context, event events.APIGatewayProxyRequest) (
 		err := fmt.Errorf("user %s does not exist", username)
 
 		logs.LogError(err, "Check For Admin Error")
-		return msgs.SendCustomError(err, 401)
+		return msgs.SendCustomError(err, 400)
 	}
 
 	admin, err := admins.RetrieveAdmin(username)

--- a/serverless/funcs/creds-2fa/main.go
+++ b/serverless/funcs/creds-2fa/main.go
@@ -98,13 +98,13 @@ func generateMfaHandler(ctx context.Context, event events.APIGatewayProxyRequest
 	}
 
 	// Ensure that the user requesting a 2FA code exists.
-	_, exists, err := users.CheckForExistingUser(username, "guests")
+	_, exists, err := users.CheckForExistingGuestUser(username)
 
 	if err != nil {
 		logs.LogError(err, "Check For User Error")
 		return msgs.SendCustomError(errors.New("load guest error"), 500)
 	} else if !exists {
-		logs.LogError(fmt.Errorf("user %s not found", username), "User Not Found Error")
+		logs.LogError(fmt.Errorf("user %s not found", username), "Guest User Not Found Error")
 		return msgs.SendCustomError(errors.New("no such user"), 404)
 	}
 

--- a/serverless/funcs/creds-salt/main.go
+++ b/serverless/funcs/creds-salt/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/IIP-Design/commons-gateway/utils/data/creds"
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
@@ -19,11 +20,15 @@ func handleCredentialRequest(username string) (creds.CredentialsData, error) {
 	var err error
 	var credentials creds.CredentialsData
 
-	_, exists, err := users.CheckForExistingUser(username, "guests")
+	_, exists, err := users.CheckForExistingGuestUser(username)
 
 	if err != nil {
+		logs.LogError(err, "Check For Guest User Error")
 		return credentials, err
 	} else if !exists {
+		err = fmt.Errorf("%s is not registered as a guest user", username)
+
+		logs.LogError(err, "Guest User Not Found Error")
 		return credentials, errors.New("user not found")
 	}
 

--- a/serverless/funcs/guest-approve/main.go
+++ b/serverless/funcs/guest-approve/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -11,6 +12,7 @@ import (
 	"github.com/IIP-Design/commons-gateway/utils/data/guests"
 	"github.com/IIP-Design/commons-gateway/utils/data/users"
 	"github.com/IIP-Design/commons-gateway/utils/email/provision"
+	"github.com/IIP-Design/commons-gateway/utils/logs"
 	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
 	"github.com/IIP-Design/commons-gateway/utils/security/hashing"
 )
@@ -24,11 +26,15 @@ func guestAcceptHandler(ctx context.Context, event events.APIGatewayProxyRequest
 	}
 
 	// Ensure that the user we intend to modify exists.
-	invitee, userExists, err := users.CheckForExistingUser(guest.Invitee, "guests")
+	invitee, userExists, err := users.CheckForExistingGuestUser(guest.Invitee)
 
 	if err != nil {
+		logs.LogError(err, "Check For Guest User Error")
 		return msgs.SendServerError(err)
 	} else if !userExists {
+		err = fmt.Errorf("%s is not registered as a guest user", guest.Invitee)
+
+		logs.LogError(err, "Guest User Not Found Error")
 		return msgs.SendCustomError(errors.New("this user has not been invited"), 404)
 	}
 
@@ -39,12 +45,14 @@ func guestAcceptHandler(ctx context.Context, event events.APIGatewayProxyRequest
 	err = guests.AcceptGuest(guest, hash, salt)
 
 	if err != nil {
+		logs.LogError(err, "Approve Invite Error")
 		return msgs.SendServerError(err)
 	}
 
 	_, err = provision.MailProvisionedCreds(invitee, pass, 0)
 
 	if err != nil {
+		logs.LogError(err, "Mail Credentials Error")
 		return msgs.SendServerError(err)
 	}
 

--- a/serverless/funcs/guest-deactivate/main.go
+++ b/serverless/funcs/guest-deactivate/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
@@ -44,17 +45,22 @@ func guestDeactivateHandler(ctx context.Context, event events.APIGatewayProxyReq
 	}
 
 	// Ensure that the user we intend to modify exists.
-	_, exists, err := users.CheckForExistingUser(id, "guests")
+	_, exists, err := users.CheckForExistingGuestUser(id)
 
-	if !exists {
-		return msgs.SendCustomError(errors.New("user does not exist"), 404)
-	} else if err != nil {
+	if err != nil {
+		logs.LogError(err, "Check For Guest User Error")
 		return msgs.SendServerError(err)
+	} else if !exists {
+		err = fmt.Errorf("%s is not registered as a guest user", id)
+
+		logs.LogError(err, "Guest User Not Found Error")
+		return msgs.SendCustomError(errors.New("user does not exist"), 404)
 	}
 
 	err = deactivateGuest(id)
 
 	if err != nil {
+		logs.LogError(err, "Deactivate Guest User Error")
 		return msgs.SendServerError(err)
 	}
 

--- a/serverless/funcs/guest-update/main.go
+++ b/serverless/funcs/guest-update/main.go
@@ -27,13 +27,15 @@ func guestUpdateHandler(ctx context.Context, event events.APIGatewayProxyRequest
 	}
 
 	// Ensure that the user we intend to modify exists.
-	_, userExists, err := users.CheckForExistingUser(guest.Email, "guests")
+	_, userExists, err := users.CheckForExistingGuestUser(guest.Email)
 
 	if err != nil {
-		logs.LogError(err, "Check For User Error")
+		logs.LogError(err, "Check For Guest User Error")
 		return msgs.SendServerError(err)
 	} else if !userExists {
-		logs.LogError(fmt.Errorf("user %s not found", guest.Email), "User Not Found Error")
+		err = fmt.Errorf("user %s is not registered as a guest", guest.Email)
+
+		logs.LogError(err, "User Not Found Error")
 		return msgs.SendCustomError(errors.New("this user has not been registered"), 404)
 	}
 

--- a/serverless/funcs/upload-metadata/main.go
+++ b/serverless/funcs/upload-metadata/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"time"
 
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
@@ -37,52 +35,6 @@ func parseRequest(body string) (RequestBody, error) {
 	return parsed, err
 }
 
-// retrieveUserId converts an admin or guest id value into a user id value.
-func retrieveUserId(email string, pool *sql.DB) (string, error) {
-	var err error
-	var userId string
-
-	// Check if user exists in the admins table
-	_, isAdmin, err := users.CheckForExistingUser(email, "admins")
-
-	if err == nil && isAdmin {
-		// Retrieve admin's the user_id from the all_users table
-		err := pool.QueryRow(`SELECT user_id FROM all_users WHERE admin_id = $1`, email).Scan(&userId)
-
-		if err != nil {
-			logs.LogError(err, "Select Admin's User Id Query Error")
-		}
-
-		return userId, err
-	} else if err == nil && !isAdmin {
-		// If not found in admin table, look in the guests table.
-		_, isGuest, err := users.CheckForExistingUser(email, "guests")
-
-		if err != nil {
-			logs.LogError(err, "Check for Guest Query Error")
-
-			return userId, err
-		}
-
-		if isGuest {
-			// Retrieve the new user id from the all_users table
-			err := pool.QueryRow(`SELECT user_id FROM all_users WHERE guest_id = $1`, email).Scan(&userId)
-
-			if err != nil {
-				logs.LogError(err, "Select Guest's User Id Query Error")
-			}
-		} else {
-			err = errors.New("user is neither an admin nor a guest")
-		}
-
-		return userId, err
-	} else if err != nil {
-		logs.LogError(err, "Check for Admin User Query Error")
-	}
-
-	return userId, err
-}
-
 // createUploadRecord opens a connection to the database and add a new upload record.
 func createUploadRecord(s3Id string, user string, teamId string, fileType string, description string) error {
 	pool := data.ConnectToDB()
@@ -90,7 +42,7 @@ func createUploadRecord(s3Id string, user string, teamId string, fileType string
 
 	currentTime := time.Now()
 
-	id, err := retrieveUserId(user, pool)
+	_, userRecord, err := users.CheckForExistingUser(user)
 
 	if err != nil {
 		logs.LogError(err, "Retrieve User Id Query Error")
@@ -99,7 +51,7 @@ func createUploadRecord(s3Id string, user string, teamId string, fileType string
 	}
 
 	query := "INSERT INTO uploads ( s3_id, user_id, team_id, file_type, description, date_uploaded ) VALUES ( $1, $2, $3, $4, $5, $6 )"
-	_, err = pool.Exec(query, s3Id, id, teamId, fileType, description, currentTime)
+	_, err = pool.Exec(query, s3Id, userRecord.UserId, teamId, fileType, description, currentTime)
 
 	if err != nil {
 		logs.LogError(err, "Create Upload Record Query Error")

--- a/serverless/utils/data/admins/admins.go
+++ b/serverless/utils/data/admins/admins.go
@@ -108,7 +108,7 @@ func RetrieveAdmin(username string) (map[string]any, error) {
 	jwt, err := jwt.GenerateJWT(username, role, false)
 
 	if err != nil {
-		logs.LogError(err, "Admin token error")
+		logs.LogError(err, "Admin Token Error")
 		return admin, err
 	}
 

--- a/serverless/utils/data/init/migration-20230831.go
+++ b/serverless/utils/data/init/migration-20230831.go
@@ -114,7 +114,7 @@ func switchUploadsUserId(pool *sql.DB) error {
 		}
 
 		// Check if user exists in the admins table
-		_, isAdmin, err := users.CheckForExistingUser(oldId, "admins")
+		_, isAdmin, err := users.CheckForExistingAdminUser(oldId)
 
 		if err == nil && isAdmin {
 			var userId string
@@ -143,7 +143,7 @@ func switchUploadsUserId(pool *sql.DB) error {
 			var userId string
 
 			// If not found in admin table, look in the guests table.
-			_, isGuest, err := users.CheckForExistingUser(oldId, "guests")
+			_, isGuest, err := users.CheckForExistingGuestUser(oldId)
 
 			if err != nil {
 				logs.LogError(err, "Check for Guest Query Error")

--- a/serverless/utils/data/users/main.go
+++ b/serverless/utils/data/users/main.go
@@ -2,16 +2,55 @@ package users
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
 	"github.com/IIP-Design/commons-gateway/utils/logs"
 )
 
-// CheckForExistingUser opens a database connection and checks whether the provided
+type UserRecord struct {
+	UserId  string
+	AdminId sql.NullString
+	GuestId sql.NullString
+	Type    string
+}
+
+// CheckIfUserExists opens a database connection and checks whether the provided
 // email (which is a unique value constraint in the admins and guests tables) is
-// present in the provided table. An affirmative check indicates that the given user
-// has the access implied by their presence in the table.
-func CheckForExistingUser(email string, table string) (data.User, bool, error) {
+// present as either an admin_id or guest_id in the all_users table. An affirmative
+// check indicates that the given user has been registered as a user in the system.
+func CheckForExistingUser(email string) (bool, UserRecord, error) {
+	var err error
+	var user UserRecord
+
+	pool := data.ConnectToDB()
+	defer pool.Close()
+
+	query := "SELECT user_id, admin_id, guest_id FROM all_users WHERE admin_id = $1 OR guest_id = $1;"
+
+	err = pool.QueryRow(query, email).Scan(&user.UserId, &user.AdminId, &user.GuestId)
+
+	if err != nil {
+		// Do not return an error if no results are found.
+		if err == sql.ErrNoRows {
+			return false, user, nil
+		}
+
+		logs.LogError(err, "Existing User Query Error")
+	}
+
+	if user.AdminId.Valid {
+		user.Type = "admin"
+	} else if user.GuestId.Valid {
+		user.Type = "guest"
+	}
+
+	return user.Type != "", user, err
+}
+
+// RetrieveExistingUser opens a database connection and and retrieves the user
+// data for a user with the provided email from the provided table.
+func retrieveExistingUser(email string, table string) (data.User, error) {
 	var err error
 
 	pool := data.ConnectToDB()
@@ -32,11 +71,73 @@ func CheckForExistingUser(email string, table string) (data.User, bool, error) {
 	if err != nil {
 		// Do not return an error if no results are found.
 		if err == sql.ErrNoRows {
-			return user, false, nil
+			return user, nil
 		}
 
 		logs.LogError(err, "Existing User Query Error")
 	}
 
-	return user, user.Email == email, err
+	return user, err
+}
+
+// CheckForExistingAdminUser opens a database connection and checks whether the
+// provided email belongs to an existing user and whether that user is an admin.
+// If the user is indeed an admin, user data will be retrieved and returned.
+func CheckForExistingAdminUser(email string) (data.User, bool, error) {
+	var userData data.User
+
+	exists, user, err := CheckForExistingUser(email)
+
+	if err != nil {
+		logs.LogError(err, "Check For User Error")
+		return userData, false, err
+	}
+
+	if exists && user.Type == "admin" {
+		userData, err = retrieveExistingUser(email, "admins")
+
+		if err != nil {
+			logs.LogError(err, "Admin Retrieval Error")
+			return userData, false, err
+		}
+
+		return userData, true, err
+	} else if exists && user.Type == "guest" {
+		logs.LogError(fmt.Errorf("user %s exists, but is not an admin", email), "Admin Retrieval Error")
+		return userData, false, err
+	}
+
+	// Handle any outlier cases
+	return userData, false, err
+}
+
+// CheckForExistingGuestUser opens a database connection and checks whether the
+// provided email belongs to an existing user and whether that user is a guest.
+// If the user is indeed a guest, user data will be retrieved and returned.
+func CheckForExistingGuestUser(email string) (data.User, bool, error) {
+	var userData data.User
+
+	exists, user, err := CheckForExistingUser(email)
+
+	if err != nil {
+		logs.LogError(err, "Check For User Error")
+		return userData, false, err
+	}
+
+	if exists && user.Type == "guest" {
+		userData, err = retrieveExistingUser(email, "guests")
+
+		if err != nil {
+			logs.LogError(err, "Guest Retrieval Error")
+			return userData, false, err
+		}
+
+		return userData, true, err
+	} else if exists && user.Type == "admin" {
+		logs.LogError(fmt.Errorf("user %s exists, but is not a guest", email), "Guest Retrieval Error")
+		return userData, false, err
+	}
+
+	// Handle any outlier cases
+	return userData, false, err
 }

--- a/serverless/utils/data/users/users_test.go
+++ b/serverless/utils/data/users/users_test.go
@@ -26,22 +26,29 @@ func TestMain(m *testing.M) {
 	os.Exit(exitVal)
 }
 
-func TestGuest(t *testing.T) {
-	_, success, err := CheckForExistingUser(testHelpers.ExampleGuest["email"], "guests")
+func TestUser(t *testing.T) {
+	success, _, err := CheckForExistingUser(testHelpers.ExampleGuest["email"])
 	if !success || err != nil {
 		t.Fatalf(`CheckForExistingUser result %t/%v, want true/nil`, success, err)
 	}
 }
 
 func TestAdmin(t *testing.T) {
-	_, success, err := CheckForExistingUser(testHelpers.ExampleAdmin["email"], "admins")
+	_, success, err := CheckForExistingAdminUser(testHelpers.ExampleAdmin["email"])
+	if !success || err != nil {
+		t.Fatalf(`CheckForExistingUser result %t/%v, want true/nil`, success, err)
+	}
+}
+
+func TestGuest(t *testing.T) {
+	_, success, err := CheckForExistingGuestUser(testHelpers.ExampleAdmin["email"])
 	if !success || err != nil {
 		t.Fatalf(`CheckForExistingUser result %t/%v, want true/nil`, success, err)
 	}
 }
 
 func TestMiss(t *testing.T) {
-	_, success, err := CheckForExistingUser("fake@test.fail", "guests")
+	success, _, err := CheckForExistingUser("fake@test.fail")
 	if success || err != nil {
 		t.Fatalf(`CheckForExistingUser result %t/%v, want true/nil`, success, err)
 	}

--- a/web/src/components/AdminForm.tsx
+++ b/web/src/components/AdminForm.tsx
@@ -152,11 +152,20 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
 
       await buildQuery( `admin?username=${escaped}`, { ...newAdmin }, 'PUT' )
         .then( () => window.location.assign( '/admins' ) )
-        .catch( err => console.error( err ) );
+        .catch( err => {
+          showError( 'Unable to update user' );
+          console.error( err );
+        } );
     } else {
-      await buildQuery( 'admin', { ...newAdmin, active: true }, 'POST' )
-        .then( () => window.location.assign( '/admins' ) )
-        .catch( err => console.error( err ) );
+      const { ok, status } = await buildQuery( 'admin', { ...newAdmin, active: true }, 'POST' );
+
+      if ( !ok && status === 409 ) {
+        showError( `The user ${adminData.email} already exists` );
+      } else if ( !ok ) {
+        showError( 'Unable to create user' );
+      } else {
+        window.location.assign( '/admins' );
+      }
     }
   };
 
@@ -188,12 +197,13 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
 
     const escaped = escapeQueryStrings( email );
 
-    await buildQuery( `admin?username=${escaped}`, { ...adminData, active: true }, 'PUT' )
-      .then( () => window.location.assign( '/admins' ) )
-      .catch( err => {
-        showError( 'Unable to reactivate user' );
-        console.error( err );
-      } );
+    const { ok } = await buildQuery( `admin?username=${escaped}`, { ...adminData, active: true }, 'PUT' );
+
+    if ( !ok ) {
+      showError( 'Unable to reactivate user' );
+    } else {
+      window.location.assign( '/admins' );
+    }
   };
 
   return (

--- a/web/src/components/NewUserForm.tsx
+++ b/web/src/components/NewUserForm.tsx
@@ -138,9 +138,13 @@ const UserForm: FC = () => {
         expiration,
       };
 
-      buildQuery( 'creds/provision', invitation, 'POST' )
-        .then( () => window.location.assign( '/' ) )
-        .catch( err => console.error( err ) );
+      const { ok } = await buildQuery( 'creds/provision', invitation, 'POST' );
+
+      if ( !ok ) {
+        showError( 'Unable to create user' );
+      } else {
+        window.location.assign( '/' );
+      }
     } else {
       const invitation = {
         proposer: currentUser.get().email,
@@ -148,11 +152,12 @@ const UserForm: FC = () => {
         expiration,
       };
 
-      try {
-        await buildQuery( 'creds/propose', invitation, 'POST' );
+      const { ok } = await buildQuery( 'creds/propose', invitation, 'POST' );
+
+      if ( !ok ) {
+        showError( 'Unable to propose user' );
+      } else {
         window.location.assign( '/uploader-users' );
-      } catch ( err ) {
-        console.error( err );
       }
     }
   };

--- a/web/src/styles/table.module.scss
+++ b/web/src/styles/table.module.scss
@@ -144,4 +144,9 @@
 .sortable-header {
   cursor: pointer;
   user-select: none;
+  line-height: 1rem;
+
+  > div {
+    margin-top: 0.25rem;
+  }
 }


### PR DESCRIPTION
This PR addresses some issues with the existing user checks that run during guest/admin creation. We currently check that the new user's email does not exist in the `admins` or `guests` table depending on what type of user is being created. However, we do not enforce that the email be globally unique across the two tables. This means that the same user can be both a guest/guest admin and an admin/super admin account.

While this PR touches many files the changes aren't too dramatic. In short, I refactored the `CheckForExistingUser` function to check whether a user exists in either table. I also added derivative functions `CheckForExistingAdminUser` and `CheckForExistingGuestUser` for use when specifically want to check if a user is an admin or guest (i.e. any non-creation operation). These function have the same signature as the older version of `CheckForExistingUser` in that they return the user data (of type `data.User`) when the user is found.

It should be noted that there is currently no mechanism to promote guest users to admins (or demote admins). While I don't believe that will be a common use case. We may want to add this functionality to the backlog.

I also added an error popup to the `NewUserForm` and `AdminForm` to indicate that user creation failed for a better user experience.

Finally, I added error logging statements throughout the updated functions where they were missing.