### PR TITLE
Allow only RFC 3986 characters in filenames

### DIFF
--- a/serverless/utils/security/sanitize/san.go
+++ b/serverless/utils/security/sanitize/san.go
@@ -839,7 +839,7 @@ var latinMap = map[string]string{
 	"ₓ": "x",
 }
 
-var SAFE_CHARACTERS_REGEX = regexp.MustCompile(`(?m)[^0-9a-zA-Z! _\.\\*'\(\)\/-]`)
+var SAFE_CHARACTERS_REGEX = regexp.MustCompile(`(?m)[^0-9a-zA-Z _\.-]`)
 var LATIN_REGEX = regexp.MustCompile(`(?m)[^A-Za-z0-9[\] ]`)
 var SPACE_REGEX = regexp.MustCompile("(?m) ")
 var TIMESTAMP_REGEX = regexp.MustCompile(`(.+)\.([^\.]+)$`)

--- a/serverless/utils/security/sanitize/san_test.go
+++ b/serverless/utils/security/sanitize/san_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestValidObjectKey(t *testing.T) {
-	objectKey := "my.great_photos-2014/jan/myvacation.jpg"
+	objectKey := "my.great_photos-2014-jan-myvacation.jpg"
 	sanitized := DefaultKeySanitizer(objectKey)
 	if objectKey != sanitized {
 		t.Fatalf(`DefaultKeySanitizer modified valid key from %s to %s`, objectKey, sanitized)
@@ -15,7 +15,7 @@ func TestValidObjectKey(t *testing.T) {
 }
 
 func TestRemoveSpaces(t *testing.T) {
-	expected := "my.great_photos-2014/jan/myvacation.jpg"
+	expected := "my.great_photos-2014janmyvacation.jpg"
 	objectKey := "    my.great_photos 2014/jan/myvacation.jpg"
 	sanitized := DefaultKeySanitizer(objectKey)
 	if sanitized != expected {
@@ -24,8 +24,17 @@ func TestRemoveSpaces(t *testing.T) {
 }
 
 func TestForbiddenChars(t *testing.T) {
-	expected := "123456!-)*_"
-	objectKey := "123#@%$^&@456!-)+=*_"
+	expected := "123456-_"
+	objectKey := "123#@%$^&@456!-+=*_"
+	sanitized := DefaultKeySanitizer(objectKey)
+	if sanitized != expected {
+		t.Fatalf(`DefaultKeySanitizer modified key to %s, expected %s`, sanitized, expected)
+	}
+}
+
+func TestPercentEncodeChars(t *testing.T) {
+	expected := "-_."
+	objectKey := "-_.!#$&'()*+,/:;=?@[]"
 	sanitized := DefaultKeySanitizer(objectKey)
 	if sanitized != expected {
 		t.Fatalf(`DefaultKeySanitizer modified key to %s, expected %s`, sanitized, expected)


### PR DESCRIPTION
Updates file sanitizer to strip any characters that would be encoded by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986).

The file "hats (1).jpg" was send from my browser to Aprimo with no errors.