### PR TITLE
fix(web): Improves consistency of back/cancel buttons

### DIFF
--- a/web/src/components/AdminForm.tsx
+++ b/web/src/components/AdminForm.tsx
@@ -19,7 +19,7 @@ import { escapeQueryStrings } from '../utils/string';
 // Styles and CSS
 // ////////////////////////////////////////////////////////////////////////////
 import '../styles/form.scss';
-import styles from '../styles/button.module.scss';
+import btnStyles from '../styles/button.module.scss';
 
 // ////////////////////////////////////////////////////////////////////////////
 // Interfaces and Types
@@ -53,6 +53,7 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
   const [isAdmin, setIsAdmin] = useState( false );
   const [teamList, setTeamList] = useState( [] );
   const [adminData, setAdminData] = useState<IAdminFormData>( initialState );
+  const [updated, setUpdated] = useState( false );
 
   // Check whether the user is an admin and set that value in state.
   // Doing so outside of a useEffect hook causes a mismatch in values
@@ -106,6 +107,7 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
    */
   const handleUpdate = ( key: keyof IAdminFormData, value?: string|Date ) => {
     setAdminData( { ...adminData, [key]: value } );
+    setUpdated( true );
   };
 
   /**
@@ -272,16 +274,17 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
       </div>
       <div style={ { textAlign: 'center' } }>
         <button
-          className={ `${styles.btn} ${styles['spaced-btn']}` }
+          className={ `${btnStyles.btn} ${btnStyles['spaced-btn']} ${updated ? "" : btnStyles['disabled-btn']}` }
           id="update-btn"
           type="submit"
+          disabled={!updated}
         >
           { admin ? 'Update Admin User' : 'Add Admin User' }
         </button>
         {
           admin && adminData.active && (
             <button
-              className={ `${styles['btn-light']} ${styles['spaced-btn']}` }
+              className={ `${btnStyles['btn-light']} ${btnStyles['spaced-btn']}` }
               id="deactivate-btn"
               type="button"
               onClick={ handleDeactivate }
@@ -293,7 +296,7 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
         {
           admin && !adminData.active && (
             <button
-              className={ `${styles['btn-light']} ${styles['spaced-btn']}` }
+              className={ `${btnStyles['btn-light']} ${btnStyles['spaced-btn']}` }
               id="deactivate-btn"
               type="button"
               onClick={ handleReactivate }
@@ -302,7 +305,7 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
             </button>
           )
         }
-        <BackButton text="Cancel" showConfirmDialog />
+        <BackButton text="Cancel" showConfirmDialog={updated} />
       </div>
     </form>
   );

--- a/web/src/components/AdminForm.tsx
+++ b/web/src/components/AdminForm.tsx
@@ -274,10 +274,10 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
       </div>
       <div style={ { textAlign: 'center' } }>
         <button
-          className={ `${btnStyles.btn} ${btnStyles['spaced-btn']} ${updated ? "" : btnStyles['disabled-btn']}` }
+          className={ `${btnStyles.btn} ${btnStyles['spaced-btn']} ${updated ? '' : btnStyles['disabled-btn']}` }
           id="update-btn"
           type="submit"
-          disabled={!updated}
+          disabled={ !updated }
         >
           { admin ? 'Update Admin User' : 'Add Admin User' }
         </button>
@@ -305,7 +305,7 @@ const AdminForm: FC<IAdminFormProps> = ( { admin } ) => {
             </button>
           )
         }
-        <BackButton text="Cancel" showConfirmDialog={updated} />
+        <BackButton text="Cancel" showConfirmDialog={ updated } />
       </div>
     </form>
   );

--- a/web/src/components/EditUserForm.tsx
+++ b/web/src/components/EditUserForm.tsx
@@ -478,9 +478,10 @@ const UserForm: FC = () => {
             ) }
           </div>
           <button
-            className={ `${btnStyles.btn} ${btnStyles['spaced-btn']}` }
+            className={ `${btnStyles.btn} ${btnStyles['spaced-btn']} ${updated ? '' : btnStyles['disabled-btn']}` }
             id="update-btn"
             type="submit"
+            disabled={ !updated }
           >
             Update Guest
           </button>

--- a/web/src/components/NewUserForm.tsx
+++ b/web/src/components/NewUserForm.tsx
@@ -48,6 +48,7 @@ const UserForm: FC = () => {
   const [isAdmin, setIsAdmin] = useState( false );
   const [teamList, setTeamList] = useState( [] );
   const [userData, setUserData] = useState<INewUserFormData>( initialState );
+  const [updated, setUpdated] = useState( false );
 
   const partnerRoles = [{ name: 'External Partner', value: 'guest' }, { name: 'External Team Lead', value: 'guest admin' }];
 
@@ -81,6 +82,7 @@ const UserForm: FC = () => {
    */
   const handleUpdate = ( key: keyof INewUserFormData, value?: string|Date ) => {
     setUserData( { ...userData, [key]: value } );
+    setUpdated( true );
   };
 
   /**
@@ -245,7 +247,7 @@ const UserForm: FC = () => {
         >
           { isAdmin ? 'Invite' : 'Propose' }
         </button>
-        <BackButton text="Cancel" showConfirmDialog />
+        <BackButton text="Cancel" showConfirmDialog={updated} />
       </div>
     </form>
   );

--- a/web/src/components/NewUserForm.tsx
+++ b/web/src/components/NewUserForm.tsx
@@ -27,7 +27,7 @@ import type { IUserFormData } from '../utils/users';
 // Styles and CSS
 // ////////////////////////////////////////////////////////////////////////////
 import '../styles/form.scss';
-import styles from '../styles/button.module.scss';
+import btnStyles from '../styles/button.module.scss';
 
 // ////////////////////////////////////////////////////////////////////////////
 // Types and Interfaces
@@ -241,13 +241,14 @@ const UserForm: FC = () => {
       </div>
       <div style={ { textAlign: 'center' } }>
         <button
-          className={ `${styles.btn} ${styles['spaced-btn']}` }
+          className={ `${btnStyles.btn} ${btnStyles['spaced-btn']} ${updated ? '' : btnStyles['disabled-btn']}` }
           id="update-btn"
           type="submit"
+          disabled={ !updated }
         >
           { isAdmin ? 'Invite' : 'Propose' }
         </button>
-        <BackButton text="Cancel" showConfirmDialog={updated} />
+        <BackButton text="Cancel" showConfirmDialog={ updated } />
       </div>
     </form>
   );

--- a/web/src/components/TableWrapper.tsx
+++ b/web/src/components/TableWrapper.tsx
@@ -31,7 +31,7 @@ const TableWrapper = <DataType, >( {
   if ( loading ) {
     return <div style={ { display: 'flex', justifyContent: 'center', width: '100%' } }><Loader /></div>;
   }
-  
+
   if ( !data.length ) {
     return <p className={ tableStyles['no-data'] }>No data to show</p>;
   }

--- a/web/src/components/TeamModal/TeamModal.tsx
+++ b/web/src/components/TeamModal/TeamModal.tsx
@@ -58,8 +58,9 @@ export const TeamModal: FC<ITeamModalProps> = ( { team, setTeams, anchor }: ITea
 
     let shouldClose = true;
 
-    if( updated && !skipConfirm ) {
+    if ( updated && !skipConfirm ) {
       const { isConfirmed } = await showConfirm( 'Are you sure you want to close the edit window?  You will lose all unsaved progress.' );
+
       shouldClose = isConfirmed;
     }
 
@@ -178,10 +179,10 @@ export const TeamModal: FC<ITeamModalProps> = ( { team, setTeams, anchor }: ITea
         ) }
         <div className={ style['btn-container'] }>
           <button
-            className={ `${btnStyles.btn} ${btnStyles['spaced-btn']} ${updated ? "" : btnStyles['disabled-btn']}` }
+            className={ `${btnStyles.btn} ${btnStyles['spaced-btn']} ${updated ? '' : btnStyles['disabled-btn']}` }
             onClick={ handleSubmit }
             type="button"
-            disabled={!updated}
+            disabled={ !updated }
           >
             Submit
           </button>

--- a/web/src/pages/upload.astro
+++ b/web/src/pages/upload.astro
@@ -32,14 +32,14 @@ const title = 'Submit Files';
   <PageContainer title={title} droppable={false}>
     <p class="section-header"><strong>Upload video or photo files <span>*</span></strong></p>
     <div class="drop-zone" id="drop-zone">
-      <strong>drag and drop files</strong>
+      <strong>Drag and drop a file</strong>
       <ul class="file-list" id="file-list"></ul>
     </div>
     <File id="add-files-button" promptText="or search your computer: " />
 
     <p class="section-header"><strong>Description <span>*</span></strong></p>
     <p class="desc-label">Include a point of contact email in case questions arise.</p>
-    <textarea id="description-text" aria-label="Enter uploaded media metadata"></textarea>
+    <textarea id="description-text" aria-label="Enter uploaded media metadata" style="resize: vertical;"></textarea>
     <Loader id="loader" style={{display: 'none'}} />
     <Button id="upload-files-btn" type="submit">Submit</Button>
   </PageContainer>

--- a/web/src/utils/files.ts
+++ b/web/src/utils/files.ts
@@ -121,6 +121,7 @@ const FILE_VALIDATION_MAP: TFileTypeMap = {
       'htm', 'html', 'shtml', 'xhtml',
     ], // Is anything other than ".html" allowed by Aprimo?
     plain: ['txt'],
+    vtt: [ 'vtt' ],
   },
   video: {
     avi: ['avi'],
@@ -182,7 +183,7 @@ const validateFile = ( { type, size, name }: File ) => {
   const extensionMatched = allowedExtensions.includes( ext );
 
   if ( !extensionMatched ) {
-    showError( 'Invalid file extension. Make sure your file extension matched the file type, such as ".docx" for a Word file.' );
+    showError( 'Invalid file extension. Make sure your file extension matches the file type, such as ".docx" for a Word file.' );
 
     return false;
   }

--- a/web/src/utils/files.ts
+++ b/web/src/utils/files.ts
@@ -121,7 +121,7 @@ const FILE_VALIDATION_MAP: TFileTypeMap = {
       'htm', 'html', 'shtml', 'xhtml',
     ], // Is anything other than ".html" allowed by Aprimo?
     plain: ['txt'],
-    vtt: [ 'vtt' ],
+    vtt: ['vtt'],
   },
   video: {
     avi: ['avi'],


### PR DESCRIPTION
Updates button function and usability as follows:

- Admin form submit button is disabled if nothing has changed
- Admin form back button prompts user only if something has changed
- Edit user form submit button is disabled if nothing has changed
- Add user form submit button is disabled if nothing has changed
- Add user form back button prompts user only if something has changed
- Team modal submit button is disabled if nothing has changed
- Team modal cancel button prompts user only if something has changed
  - Does not prompt if updates have been saved
  - Does not keep edits for a new team if modal is closed

Also includes misc. other UI updates:

- Fix error handling on team create/update so messages properly display
- Clarify upload drop zone verbiage
- Prevent unwanted upload description area resizing
- Add VTT to allowed file types (tested end-to-end with Aprimo)
- Fix file upload error wording
- Misc. linter issues