### PR TITLE
Convert file extension to lowercase before compare

### DIFF
--- a/web/src/utils/files.ts
+++ b/web/src/utils/files.ts
@@ -145,7 +145,7 @@ const FILE_VALIDATION_MAP: TFileTypeMap = {
 const fileExtension = ( fileName: string ) => {
   const segments = fileName.split( '.' );
 
-  return segments[segments.length - 1];
+  return segments[segments.length - 1]?.toLowerCase();
 };
 
 const typeInfo = ( fileType: string ) => {


### PR DESCRIPTION
This should have been included from the beginning, but wasn't.  Files downloaded from Aprimo have their extensions cased like ".Pdf," which keeps them from being uploaded despite being otherwise valid.