### PR TITLE
Emails Fixes

### DIFF
--- a/serverless/config/functions/guest.yml
+++ b/serverless/config/functions/guest.yml
@@ -207,6 +207,10 @@ guestReauth:
   package:
     patterns:
       - './bin/guest-reauth'
+  environment:
+    AWS_SES_REGION: ${env:AWS_SES_REGION}
+    EMAIL_REDIRECT_URL: ${env:CLIENT_URL}/partner-login
+    SOURCE_EMAIL_ADDRESS: ${env:AWS_SES_EMAIL}
 passwordChange:
   name: gateway-${opt:stage}-password-change
   handler: bin/password-change
@@ -222,10 +226,10 @@ passwordChange:
         cors: ${file(./config/${param:deployment}.json):cors}
         request:
           schemas:
-              application/json:
-                schema: ${file(./funcs/password-change/schema.json)}
-                name: PostPasswordChangeModel
-                description: Validation model for changing a password.
+            application/json:
+              schema: ${file(./funcs/password-change/schema.json)}
+              name: PostPasswordChangeModel
+              description: Validation model for changing a password.
   package:
     patterns:
       - './bin/password-change'

--- a/serverless/funcs/creds-propose/main.go
+++ b/serverless/funcs/creds-propose/main.go
@@ -42,7 +42,9 @@ func handleProposedInvitation(invite data.Invite) error {
 		return err
 	}
 
-	err = propose.MailProposedCreds(invite.Invitee, proposer)
+	fmt.Printf("Sending %s their temporary credentials\n", invite.Invitee.Email)
+
+	err = propose.MailProposedInvite(proposer, invite.Invitee)
 
 	return err
 }

--- a/serverless/funcs/creds-propose/main.go
+++ b/serverless/funcs/creds-propose/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/IIP-Design/commons-gateway/utils/data/admins"
 	"github.com/IIP-Design/commons-gateway/utils/data/creds"
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
 	"github.com/IIP-Design/commons-gateway/utils/email/propose"
+	"github.com/IIP-Design/commons-gateway/utils/logs"
 	msgs "github.com/IIP-Design/commons-gateway/utils/messages"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -22,13 +24,21 @@ func handleProposedInvitation(invite data.Invite) error {
 	proposer, active, err := admins.CheckForGuestAdmin(invite.Proposer)
 
 	if err != nil {
+		logs.LogError(err, "Admin Check Error")
 		return err
 	} else if !active {
+		err = fmt.Errorf("the user %s is not authorized propose user invites", proposer.Email)
+
+		logs.LogError(err, "Admin Check Error")
 		return errors.New("you are not authorized to propose user invites")
 	}
 
+	fmt.Printf("Registering the invitation of %s by %s\n", invite.Invitee.Email, proposer.Email)
+
 	_, err = creds.SaveInitialInvite(invite, true)
+
 	if err != nil {
+		logs.LogError(err, "Save Credentials Error")
 		return err
 	}
 
@@ -46,12 +56,14 @@ func proposalHandler(ctx context.Context, event events.APIGatewayProxyRequest) (
 	invite, err := data.ExtractInvite(event.Body)
 
 	if err != nil {
+		logs.LogError(err, "Extract Invite Error")
 		return msgs.SendServerError(err)
 	}
 
 	err = handleProposedInvitation(invite)
 
 	if err != nil {
+		logs.LogError(err, "Handle Proposed Invite Error")
 		return msgs.SendServerError(err)
 	}
 

--- a/serverless/funcs/guest-reauth/main.go
+++ b/serverless/funcs/guest-reauth/main.go
@@ -72,7 +72,7 @@ func guestReauthHandler(ctx context.Context, event events.APIGatewayProxyRequest
 			return msgs.SendServerError(err)
 		}
 
-		err = propose.MailProposedCreds(user, proposer)
+		err = propose.MailProposedInvite(proposer, user)
 
 		if err != nil {
 			logs.LogError(err, "Mail Proposed Creds Error")

--- a/serverless/utils/data/guests/guests.go
+++ b/serverless/utils/data/guests/guests.go
@@ -85,6 +85,23 @@ func RetrieveGuest(email string) (GuestDetails, error) {
 	return guest, err
 }
 
+// RetrieveGuestExpiration opens a database connection and retrieves a single user's access expiration.
+func RetrieveGuestExpiration(email string) (time.Time, error) {
+	var expires time.Time
+
+	pool := data.ConnectToDB()
+	defer pool.Close()
+
+	query := `SELECT expiration FROM invites WHERE invitee = $1 ORDER BY date_invited DESC LIMIT 1`
+	err := pool.QueryRow(query, email).Scan(&expires)
+
+	if err != nil {
+		logs.LogError(err, "Retrieve Guest Expiration Query Error")
+	}
+
+	return expires, err
+}
+
 // RetrieveGuests opens a database connection and retrieves the full list of guest users.
 func RetrieveGuests(team string, role string) ([]data.GuestUser, error) {
 	var guests []data.GuestUser

--- a/serverless/utils/email/propose/propose.go
+++ b/serverless/utils/email/propose/propose.go
@@ -121,7 +121,10 @@ func formatEmail(
 	}
 }
 
-func MailProposedCreds(proposer data.User, invitee data.User) error {
+// MailProposedInvite sends an email to all admins of the relevant team, informing
+// them that the proposer has requested access for a new user (the invitee). The
+// list of recipient admin is derived from the team to which the proposer is assigned.
+func MailProposedInvite(proposer data.User, invitee data.User) error {
 	sourceEmail := os.Getenv("SOURCE_EMAIL_ADDRESS")
 	redirectUrl := os.Getenv("EMAIL_REDIRECT_URL")
 

--- a/serverless/utils/email/propose/propose.go
+++ b/serverless/utils/email/propose/propose.go
@@ -2,8 +2,8 @@ package propose
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/IIP-Design/commons-gateway/utils/data/data"
@@ -25,6 +25,7 @@ type RequestSupportStaffData struct {
 	Url      string    `json:"url"`
 }
 
+// getAdmins retrieves a list of admins assigned to a given team.
 func getAdmins(team string) ([]data.User, error) {
 	var admins []data.User
 
@@ -67,23 +68,27 @@ func getAdmins(team string) ([]data.User, error) {
 	return admins, nil
 }
 
+// formatEmailBody populates the template of the invite proposal
+// notification email with the relevant values.
 func formatEmailBody(
 	proposer data.User,
 	invitee data.User,
 	admin data.User,
 	url string,
 ) string {
-	return fmt.Sprintf(`<p>%s %s,</p> 
-	<p>%s %s has submitted a ticket for adding
-	 %s %s for your approval.
-	  Please follow <a href="%s">this link</a> to approve or deny this request.</p>
-	<p>This email was generated automatically. Please do not reply to this email.</p>`,
+	return fmt.Sprintf(
+		`<p>%s %s,</p>
+		 <p>%s %s has submitted a ticket for adding %s %s for your approval. Please follow <a href="%s">this link</a> to approve or deny this request.</p>
+		 <p>This email was generated automatically. Please do not reply to this email.</p>`,
 		admin.NameFirst, admin.NameLast,
 		proposer.NameFirst, proposer.NameLast,
 		invitee.NameFirst, invitee.NameLast,
-		url)
+		url,
+	)
 }
 
+// formatEmail prepares the event object that is sent to SES in order
+// to initiate the invite proposal notification email.
 func formatEmail(
 	proposer data.User,
 	invitee data.User,
@@ -121,7 +126,9 @@ func MailProposedCreds(proposer data.User, invitee data.User) error {
 	redirectUrl := os.Getenv("EMAIL_REDIRECT_URL")
 
 	if sourceEmail == "" {
-		log.Println("Not configured for sending emails")
+		err := errors.New("not configured for sending emails")
+
+		logs.LogError(err, "Missing Source Email Error")
 		return nil
 	}
 
@@ -130,12 +137,16 @@ func MailProposedCreds(proposer data.User, invitee data.User) error {
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
 		config.WithRegion(awsRegion),
 	)
+
 	if err != nil {
+		logs.LogError(err, "Error Loading AWS Configuration")
 		return err
 	}
 
 	admins, err := getAdmins(proposer.Team)
+
 	if err != nil {
+		logs.LogError(err, "Get Admins Error")
 		return err
 	}
 
@@ -151,8 +162,9 @@ func MailProposedCreds(proposer data.User, invitee data.User) error {
 		)
 
 		_, err := sesClient.SendEmail(context.TODO(), &e)
+
 		if err != nil {
-			log.Println(err.Error())
+			logs.LogError(err, "Send Error")
 		}
 
 	}


### PR DESCRIPTION
Addresses a few issues with user email notifications.

1. Corrects the order in which the proposer and guest are listed in the invitiation proposal notification. Essentially, we were passing the proposer and guest arguments into the `MailProposedCreds` function in the wrong order.
1. Adds missing environmental variables to the guest reauthorization Lambda
1. Adds a line to the user temporary credentials notification informing the guest user when their access expires.
1. Adds some additional logging for easier trouble shooting